### PR TITLE
Add name prefixes to geometries and freejoints

### DIFF
--- a/sdformat_mjcf_utils/sdformat_mjcf_utils/sdf_utils.py
+++ b/sdformat_mjcf_utils/sdformat_mjcf_utils/sdf_utils.py
@@ -18,6 +18,8 @@ Python"""
 import math
 from ignition.math import Pose3d, Vector3d
 
+NAME_DELIMITER = '_'
+
 
 def vec3d_to_list(vec):
     """Convert a Vector3d object to a list.
@@ -57,6 +59,20 @@ def quat_to_euler_list(quat):
     :rtype: list[float]
     """
     return [math.degrees(val) for val in vec3d_to_list(quat.euler())]
+
+
+def prefix_name(prefix, name):
+    """
+    Prefixes a given `name` with `prefix`.
+    :param str prefix: The prefix. If this is None or "world", the name is
+    returned without being prefixed.
+    :param str name: Name to prefix.
+    :return: Prefixed name.
+    :rtype: str
+    """
+    if prefix is None or prefix == "world":
+        return name
+    return prefix + NAME_DELIMITER + name
 
 
 class GraphResolverImplBase:

--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/geometry.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/geometry.py
@@ -41,9 +41,10 @@ def add_geometry(body, name, pose, sdf_geom):
     if sdf_geom is None:
         return
 
+    prefixed_name = su.prefix_name(body.name, name)
     geom = body.add(
         "geom",
-        name=name,
+        name=prefixed_name,
         pos=su.vec3d_to_list(pose.pos()),
         euler=su.quat_to_euler_list(pose.rot()),
     )

--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/joint.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/joint.py
@@ -66,7 +66,8 @@ def add_joint(body, joint):
     :rtype: mjcf.Element
     """
     if joint is None:
-        return body.add("freejoint", name="freejoint")
+        return body.add("freejoint",
+                        name=su.prefix_name(body.name, "freejoint"))
     elif joint.type() == JointType.FIXED:
         return None
     elif joint.type() in [

--- a/sdformat_to_mjcf/tests/test_add_geometry.py
+++ b/sdformat_to_mjcf/tests/test_add_geometry.py
@@ -183,9 +183,6 @@ class GeometryTest(helpers.TestCase):
 
 class CollisionTest(helpers.TestCase):
 
-    def setUp(self):
-        helpers.setup_test_graph_resolver()
-
     def test_basic_collision_attributes(self):
         collision = sdf.Collision()
         collision.set_name("c1")

--- a/sdformat_to_mjcf/tests/test_add_joint.py
+++ b/sdformat_to_mjcf/tests/test_add_joint.py
@@ -34,7 +34,7 @@ class JointTest(helpers.TestCase):
 
     def setUp(self):
         self.mujoco = mjcf.RootElement(model="test")
-        self.body = self.mujoco.worldbody.add("body")
+        self.body = self.mujoco.worldbody.add("body", name="base_link")
 
     def create_sdf_joint(self,
                          name,
@@ -65,8 +65,17 @@ class JointTest(helpers.TestCase):
     def test_free_joint(self):
         mj_joint = add_joint(self.body, None)
         self.assertIsNotNone(mj_joint)
-        self.assertEqual("freejoint", mj_joint.name)
+        self.assertEqual(su.prefix_name("base_link", "freejoint"),
+                         mj_joint.name)
         self.assertEqual("freejoint", mj_joint.tag)
+
+    def test_multilpe_free_joints(self):
+        mj_joint1 = add_joint(self.body, None)
+        self.assertIsNotNone(mj_joint1)
+        # Add another body with a free joint to worldbody
+        body2 = self.mujoco.worldbody.add("body", name="test_body")
+        mj_joint2 = add_joint(body2, None)
+        self.assertIsNotNone(mj_joint2)
 
     def test_fixed_joint(self):
         joint = sdf.Joint()

--- a/sdformat_to_mjcf/tests/test_add_link.py
+++ b/sdformat_to_mjcf/tests/test_add_link.py
@@ -21,6 +21,7 @@ from ignition.math import Inertiald, Pose3d, MassMatrix3d, Vector3d
 from dm_control import mjcf
 
 from sdformat_to_mjcf.converters.link import add_link
+import sdformat_mjcf_utils.sdf_utils as su
 from tests import helpers
 
 GeometryType = sdf.Geometry.GeometryType
@@ -44,6 +45,15 @@ class LinkTest(helpers.TestCase):
             moi(0, 2),
             moi(1, 2)
         ]
+
+    def create_box(self, sdf_cls, name):
+        item = sdf_cls()
+        item.set_name(name)
+        geometry = sdf.Geometry()
+        geometry.set_box_shape(sdf.Box())
+        geometry.set_type(GeometryType.BOX)
+        item.set_geometry(geometry)
+        return item
 
     def test_basic_link(self):
         link = sdf.Link()
@@ -122,8 +132,34 @@ class LinkTest(helpers.TestCase):
         assert_allclose(self.expected_euler, mj_body.euler)
         geoms = mj_body.find_all('geom')
         self.assertEqual(2, len(geoms))
-        self.assertEqual("c1", geoms[0].name)
-        self.assertEqual("v1", geoms[1].name)
+        self.assertEqual(su.prefix_name("base_link", "c1"), geoms[0].name)
+        self.assertEqual(su.prefix_name("base_link", "v1"), geoms[1].name)
+
+    def test_duplicate_collision_names(self):
+        c1 = self.create_box(sdf.Collision, "c1")
+        link1 = sdf.Link()
+        link1.set_name("link1")
+        link1.add_collision(c1)
+        link2 = sdf.Link()
+        link2.set_name("link2")
+        link2.add_collision(c1)
+        mj_body1 = add_link(self.body, link1)
+        mj_body2 = add_link(self.body, link2)
+        self.assertIsNotNone(mj_body1)
+        self.assertIsNotNone(mj_body2)
+
+    def test_duplicate_visual(self):
+        v1 = self.create_box(sdf.Visual, "v1")
+        link1 = sdf.Link()
+        link1.set_name("link1")
+        link1.add_visual(v1)
+        link2 = sdf.Link()
+        link2.set_name("link2")
+        link2.add_visual(v1)
+        mj_body1 = add_link(self.body, link1)
+        mj_body2 = add_link(self.body, link2)
+        self.assertIsNotNone(mj_body1)
+        self.assertIsNotNone(mj_body2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# 🎉 Bug Fix

Closes #8 

## Summary
It is possible for SDFormat files to have collisions or visuals in
different links have the same name, but this is not allowed in MJCF. To
prevent this name collision, we prefix the names of geoms with the names
of their parent bodies.

This also changes how freejoints are named since it is possible to have
multiple freejoints in the world.

The delimiter `_` is chosen as opposed to `/` or `::` because these two
have special meaning in MJCF and SDFormat respectively.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
