### PR TITLE
Add conversion for SDFormat Models

### DIFF
--- a/sdformat_mjcf_utils/sdformat_mjcf_utils/sdf_utils.py
+++ b/sdformat_mjcf_utils/sdformat_mjcf_utils/sdf_utils.py
@@ -68,6 +68,12 @@ class GraphResolverImplBase:
     def resolve_axis_xyz(self, joint_axis):
         raise NotImplementedError
 
+    def resolve_parent_link_name(self, joint):
+        raise NotImplementedError
+
+    def resolve_child_link_name(self, joint):
+        raise NotImplementedError
+
 
 class GraphResolverImpl(GraphResolverImplBase):
     """Implementation of different pose and frame resolution functions."""
@@ -104,6 +110,32 @@ class GraphResolverImpl(GraphResolverImplBase):
         xyz_vec = Vector3d()
         self._handle_errors(joint_axis.resolve_xyz(xyz_vec))
         return xyz_vec
+
+    def resolve_parent_link_name(self, joint):
+        """
+        Resolves the parent link name of an SDFormat Joint.
+        :param sdformat.Joint joint: The Joint object.
+        :return: The resolved name of the parent link.
+        :rtype: str
+        :raises RuntimeError: if an error is encountered when resolving the
+        the link.
+        """
+        errors, parent_link_name = joint.resolve_parent_link()
+        self._handle_errors(errors)
+        return parent_link_name
+
+    def resolve_child_link_name(self, joint):
+        """
+        Resolves the child link name of an SDFormat Joint.
+        :param sdformat.Joint joint: The Joint object.
+        :return: The resolved name of the child link.
+        :rtype: str
+        :raises RuntimeError: if an error is encountered when resolving the
+        the link.
+        """
+        errors, child_link_name = joint.resolve_child_link()
+        self._handle_errors(errors)
+        return child_link_name
 
     def _handle_errors(self, errors):
         if errors:

--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/model.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/model.py
@@ -31,7 +31,6 @@ def add_model(mjcf_root, model):
     """
 
     kin_hierarchy = KinematicHierarchy(model)
-    mjcf_root.model = model.name()
     model_pose = graph_resolver.resolve_pose(model.semantic_pose())
 
     def convert_node(body, node):

--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/model.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/model.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2022 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sdformat_to_mjcf.sdf_kinematics import KinematicHierarchy
+from sdformat_to_mjcf.converters.link import add_link
+from sdformat_to_mjcf.converters.joint import add_joint
+from sdformat_mjcf_utils.sdf_utils import graph_resolver
+
+
+def add_model(mjcf_root, model):
+    """
+    Converts a model from SDFormat to MJCF and add it to the given
+    MJCF root.
+
+    :param mjcf.RootElement mjcf_root: The MJCF root element to which the model
+    is added.
+    :param sdformat.Model model: The SDFormat model to be converted.
+    :return: The newly created MJCF body.
+    :rtype: mjcf.Element
+    """
+
+    kin_hierarchy = KinematicHierarchy(model)
+    mjcf_root.model = model.name()
+    model_pose = graph_resolver.resolve_pose(model.semantic_pose())
+
+    def convert_node(body, node):
+        child_body = add_link(body,
+                              node.link,
+                              node.parent_node.link.name())
+
+        add_joint(child_body, node.joint)
+
+        for cn in node.child_nodes:
+            convert_node(child_body, cn)
+
+    for cn in kin_hierarchy.world_node.child_nodes:
+        # Adjust the poses of each of the nodes to account for the model
+        link_pose = graph_resolver.resolve_pose(cn.link.semantic_pose())
+        new_link_pose = model_pose * link_pose
+        cn.link.set_raw_pose(new_link_pose)
+        cn.link.set_pose_relative_to("")
+        convert_node(mjcf_root.worldbody, cn)
+
+    return mjcf_root

--- a/sdformat_to_mjcf/sdformat_to_mjcf/sdf_kinematics.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/sdf_kinematics.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2022 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sdformat as sdf
+import sdformat_mjcf_utils.sdf_utils as su
+
+
+class LinkNode:
+    """
+    A Node that represents links/bodies in KinematicHierarchy defined below.
+    """
+    def __init__(self, link, parent=None, joint=None):
+        """
+        Initialize the node with an SDFormat link, an optional parent node and
+        an optional joint
+        :param sdformat.Link link: The SDFormat link associated with this node.
+        :param LinkNode parent: The parent link node.
+        :param sdformat.Joint joint: The SDFormat joint whose <child> tag
+        refers to the link assocated with this node.
+        """
+        self.link = link
+        self.parent_node = parent
+        self.joint = joint
+        self.child_nodes = []
+
+    def __repr__(self):
+        child_repr = " ".join(str(node) for node in self.child_nodes)
+        return f"{self.link.name()}->({child_repr})"
+
+    def add_child(self, node, joint):
+        """
+        Add a child node and set the node's parent_node attribute to this node.
+        :param LinkNode node: The child node to be added
+        :param sdformat.Joint joint: The SDFormat joint that whose <child> tag
+        refers to the link assocated with this node.
+        """
+        node.parent_node = self
+        node.joint = joint
+        self.child_nodes.append(node)
+
+    def remove_child(self, node):
+        """
+        Remove a child node. This also clears the node's parent_node attribute.
+        :param LinkNode node: The child node to be removed.
+        """
+        node.parent_node = None
+        self.child_nodes.remove(node)
+
+
+class KinematicHierarchy:
+    """
+    Used to build a kinematic hierarchy (currently, only tree) of links from an
+    SDFormat Model. The root of the hierarchy is the world link, which
+    corresponds to MJCFs worldbody. Unconnected links found in the model are
+    made children of the world link connected by a free joint.
+    """
+    def __init__(self, model):
+        """
+        Initialize a Kinematicierarchy from an SDFormat Model
+
+        :param sdformat.Model model: The SDFormat model for building the
+        hierarchy.
+        """
+        self.world_link = sdf.Link()
+        self.world_link.set_name("world")
+        self.world_node = LinkNode(self.world_link)
+
+        link_to_node_dict = {self.world_link: self.world_node}
+
+        # Start with every link being a child of world link. Later on, we will
+        # process joints to build the hierarchy.
+        for li in range(model.link_count()):
+            node = LinkNode(model.link_by_index(li), self.world_node)
+            link_to_node_dict[node.link] = node
+            self.world_node.add_child(node, None)
+
+        for ji in range(model.joint_count()):
+            joint = model.joint_by_index(ji)
+            parent_link_name = su.graph_resolver.resolve_parent_link_name(
+                joint)
+            parent = model.link_by_name(parent_link_name)
+            if parent_link_name == "world":
+                parent = self.world_link
+
+            child_link_name = su.graph_resolver.resolve_child_link_name(joint)
+            # TODO (azeey) We assume that the child link is in the current
+            # model, i.e., not nested. Remove this assumption when we support
+            # nesting.
+            child_node = link_to_node_dict[model.link_by_name(child_link_name)]
+
+            self.world_node.remove_child(child_node)
+            link_to_node_dict[parent].add_child(child_node, joint)

--- a/sdformat_to_mjcf/tests/helpers.py
+++ b/sdformat_to_mjcf/tests/helpers.py
@@ -34,6 +34,18 @@ class TestGraphResolverImpl(su.GraphResolverImplBase):
         except RuntimeError:
             return joint_axis.xyz()
 
+    def resolve_parent_link_name(self, joint):
+        try:
+            return super().resolve_parent_link_name(joint)
+        except RuntimeError:
+            return joint.parent_link_name()
+
+    def resolve_child_link_name(self, joint):
+        try:
+            return super().resolve_child_link_name(joint)
+        except RuntimeError:
+            return joint.child_link_name()
+
 
 def setup_test_graph_resolver():
     su.graph_resolver.resolver = TestGraphResolverImpl()

--- a/sdformat_to_mjcf/tests/resources/double_pendulum.sdf
+++ b/sdformat_to_mjcf/tests/resources/double_pendulum.sdf
@@ -1,0 +1,210 @@
+<?xml version='1.0'?>
+<sdf version="1.4">
+  <model name="double_pendulum_with_base">
+    <joint name="fix_to_world" type="fixed">
+      <parent>world</parent>
+      <child>base</child>
+    </joint>
+    <link name="base">
+      <inertial>
+        <mass>100</mass>
+        <pose>1 0 0  0 0 0</pose>
+      </inertial>
+      <visual name="vis_plate_on_ground">
+        <pose>0 0 0.01  0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.8</radius>
+            <length>0.02</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+      <visual name="vis_pole">
+        <pose>-0.275 0 1.1  0 0 0</pose>
+        <geometry>
+          <box><size>0.2 0.2 2.2</size></box>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+      <collision name="col_plate_on_ground">
+        <pose>0 0 0.01  0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.8</radius>
+            <length>0.02</length>
+          </cylinder>
+        </geometry>
+      </collision>
+      <collision name="col_pole">
+        <pose>-0.275 0 1.1  0 0 0</pose>
+        <geometry>
+          <box><size>0.2 0.2 2.2</size></box>
+        </geometry>
+      </collision>
+    </link>
+    <!-- upper link, length 1, IC -90 degrees -->
+    <link name="upper_link">
+      <pose>0 0 2.1  -1.5708 0 0</pose>
+      <self_collide>0</self_collide>
+      <inertial>
+        <mass>2</mass>
+        <pose>0 0 0.5  0 0 0</pose>
+      </inertial>
+      <visual name="vis_upper_joint">
+        <pose>-0.05 0 0  0 1.5708 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.1</radius>
+            <length>0.3</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+      <visual name="upper_link_vis_lower_joint">
+        <pose>0 0 1.0  0 1.5708 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.1</radius>
+            <length>0.2</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+      <visual name="upper_link_vis_cylinder">
+        <pose>0 0 0.5  0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.1</radius>
+            <length>0.9</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+      <collision name="col_upper_joint">
+        <pose>-0.05 0 0  0 1.5708 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.1</radius>
+            <length>0.3</length>
+          </cylinder>
+        </geometry>
+      </collision>
+      <collision name="col_lower_joint">
+        <pose>0 0 1.0  0 1.5708 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.1</radius>
+            <length>0.2</length>
+          </cylinder>
+        </geometry>
+      </collision>
+      <collision name="col_cylinder">
+        <pose>0 0 0.5  0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.1</radius>
+            <length>0.9</length>
+          </cylinder>
+        </geometry>
+      </collision>
+    </link>
+    <!-- lower link, length 1, IC ~-120 degrees more -->
+    <link name="lower_link">
+      <pose>0.25 1.0 2.1  -2 0 0</pose>
+      <self_collide>0</self_collide>
+      <inertial>
+        <pose>0 0 0.5  0 0 0</pose>
+      </inertial>
+      <visual name="vis_lower_joint">
+        <pose>0 0 0  0 1.5708 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.08</radius>
+            <length>0.3</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+      <visual name="vis_cylinder">
+        <pose>0 0 0.5  0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.1</radius>
+            <length>0.9</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+      <collision name="col_lower_joint2">
+        <pose>0 0 0  0 1.5708 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.08</radius>
+            <length>0.3</length>
+          </cylinder>
+        </geometry>
+      </collision>
+      <collision name="col_cylinder2">
+        <pose>0 0 0.5  0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.1</radius>
+            <length>0.9</length>
+          </cylinder>
+        </geometry>
+      </collision>
+    </link>
+    <!-- pin joint for upper link, at origin of upper link -->
+    <joint name="upper_joint" type="revolute">
+      <parent>base</parent>
+      <child>upper_link</child>
+      <axis>
+        <xyz>1.0 0 0</xyz>
+      </axis>
+    </joint>
+    <!-- pin joint for lower link, at origin of child link -->
+    <joint name="lower_joint" type="revolute">
+      <parent>upper_link</parent>
+      <child>lower_link</child>
+      <axis>
+        <xyz>1.0 0 0</xyz>
+      </axis>
+    </joint>
+  </model>
+</sdf>

--- a/sdformat_to_mjcf/tests/test_add_model.py
+++ b/sdformat_to_mjcf/tests/test_add_model.py
@@ -1,0 +1,151 @@
+# Copyright (C) 2022 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from numpy.testing import assert_allclose
+from math import pi
+
+import sdformat as sdf
+from ignition.math import Pose3d
+from dm_control import mjcf
+
+from sdformat_to_mjcf.converters.model import add_model
+import sdformat_mjcf_utils.sdf_utils as su
+from tests import helpers
+
+GeometryType = sdf.Geometry.GeometryType
+JointType = sdf.Joint.JointType
+
+
+class ModelTest(unittest.TestCase):
+    test_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)
+    expected_pos = [1.0, 2.0, 3.0]
+    expected_euler = [90.0, 60.0, 45.0]
+
+    def setUp(self):
+        helpers.setup_test_graph_resolver()
+        self.mujoco = mjcf.RootElement(model="test")
+
+    def test_basic_model(self):
+        model = sdf.Model()
+        model.set_name("test_model")
+        model.set_raw_pose(self.test_pose)
+
+        base_link = sdf.Link()
+        base_link.set_name("base_link")
+        model.add_link(base_link)
+
+        mj_root = add_model(self.mujoco, model)
+        self.assertIsNotNone(mj_root)
+        self.assertEqual("test_model", mj_root.model)
+        mj_bodies = mj_root.worldbody.get_children("body")
+        self.assertEqual(1, len(mj_bodies))
+        self.assertEqual("base_link", mj_bodies[0].name)
+
+        assert_allclose(self.expected_pos, mj_bodies[0].pos)
+        assert_allclose(self.expected_euler, mj_bodies[0].euler)
+
+    def test_model_multiple_floating_links(self):
+        model_raw_pose = self.test_pose
+        model = sdf.Model()
+        model.set_name("test_model")
+        model.set_raw_pose(model_raw_pose)
+
+        float_link_1 = sdf.Link()
+        float_link_1.set_name("float_link_1")
+        model.add_link(float_link_1)
+
+        float_link_2 = sdf.Link()
+        float_link_2.set_name("float_link_2")
+        float_link_2_raw_pose = Pose3d(-0.1, -0.2, -0.3, 0, 0, 0)
+        float_link_2.set_raw_pose(float_link_2_raw_pose)
+        model.add_link(float_link_2)
+
+        mj_root = add_model(self.mujoco, model)
+        self.assertIsNotNone(mj_root)
+        self.assertEqual("test_model", mj_root.model)
+
+        mj_float_link_1 = mj_root.worldbody.find('body', 'float_link_1')
+        self.assertIsNotNone(mj_float_link_1)
+
+        mj_float_link_2 = mj_root.worldbody.find('body', 'float_link_2')
+        self.assertIsNotNone(mj_float_link_2)
+
+        float_link_1_expected_pos = su.vec3d_to_list(model_raw_pose.pos())
+        float_link_1_expected_euler = su.quat_to_euler_list(
+            model_raw_pose.rot())
+        assert_allclose(float_link_1_expected_pos, mj_float_link_1.pos)
+        assert_allclose(float_link_1_expected_euler, mj_float_link_1.euler)
+
+        float_link_2_expected_pose = model_raw_pose * float_link_2_raw_pose
+        float_link_2_expected_pos = su.vec3d_to_list(
+            float_link_2_expected_pose.pos())
+        float_link_2_expected_euler = su.quat_to_euler_list(
+            float_link_2_expected_pose.rot())
+        assert_allclose(float_link_2_expected_pos, mj_float_link_2.pos)
+        assert_allclose(float_link_2_expected_euler, mj_float_link_2.euler)
+
+    def test_model_multiple_links_with_joint(self):
+        model_raw_pose = self.test_pose
+        model = sdf.Model()
+        model.set_name("test_model")
+        model.set_raw_pose(model_raw_pose)
+
+        base_link = sdf.Link()
+        base_link.set_name("base_link")
+        model.add_link(base_link)
+
+        upper_link = sdf.Link()
+        upper_link.set_name("upper_link")
+        upper_link_raw_pose = Pose3d(-0.1, -0.2, -0.3, 0, 0, 0)
+        upper_link.set_raw_pose(upper_link_raw_pose)
+        model.add_link(upper_link)
+
+        joint = sdf.Joint()
+        joint.set_name("joint")
+        joint.set_type(JointType.FIXED)
+        joint.set_parent_link_name("base_link")
+        joint.set_child_link_name("upper_link")
+        model.add_joint(joint)
+
+        mj_root = add_model(self.mujoco, model)
+        self.assertIsNotNone(mj_root)
+        self.assertEqual("test_model", mj_root.model)
+
+        mj_base_link = mj_root.worldbody.find('body', 'base_link')
+        self.assertIsNotNone(mj_base_link)
+
+        mj_upper_link = mj_root.worldbody.find('body', 'upper_link')
+        self.assertIsNotNone(mj_upper_link)
+
+        base_link_expected_pos = su.vec3d_to_list(model_raw_pose.pos())
+        base_link_expected_euler = su.quat_to_euler_list(model_raw_pose.rot())
+        assert_allclose(base_link_expected_pos, mj_base_link.pos)
+        assert_allclose(base_link_expected_euler, mj_base_link.euler)
+
+        # upper_link has a pose `upper_link_raw_pose` relative to the model
+        # frame. If it a floating body under worldbody, it's pose would be:
+        # `model_raw_pose * upper_link_raw_pose`. However, since it's a child
+        # of `base_link`, and since `base_link` has identity pose, the pose of
+        # `upper_link` relative to `base_link` is just `upper_link_raw_pose`.
+        # i.e., `model_raw_pose` does not affect the poser of upper_link
+        upper_link_expected_pos = su.vec3d_to_list(upper_link_raw_pose.pos())
+        upper_link_expected_euler = su.quat_to_euler_list(
+            upper_link_raw_pose.rot())
+        assert_allclose(upper_link_expected_pos, mj_upper_link.pos)
+        assert_allclose(upper_link_expected_euler, mj_upper_link.euler)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdformat_to_mjcf/tests/test_add_model.py
+++ b/sdformat_to_mjcf/tests/test_add_model.py
@@ -28,13 +28,12 @@ GeometryType = sdf.Geometry.GeometryType
 JointType = sdf.Joint.JointType
 
 
-class ModelTest(unittest.TestCase):
+class ModelTest(helpers.TestCase):
     test_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)
     expected_pos = [1.0, 2.0, 3.0]
     expected_euler = [90.0, 60.0, 45.0]
 
     def setUp(self):
-        helpers.setup_test_graph_resolver()
         self.mujoco = mjcf.RootElement(model="test")
 
     def test_basic_model(self):
@@ -48,7 +47,6 @@ class ModelTest(unittest.TestCase):
 
         mj_root = add_model(self.mujoco, model)
         self.assertIsNotNone(mj_root)
-        self.assertEqual("test_model", mj_root.model)
         mj_bodies = mj_root.worldbody.get_children("body")
         self.assertEqual(1, len(mj_bodies))
         self.assertEqual("base_link", mj_bodies[0].name)
@@ -74,7 +72,6 @@ class ModelTest(unittest.TestCase):
 
         mj_root = add_model(self.mujoco, model)
         self.assertIsNotNone(mj_root)
-        self.assertEqual("test_model", mj_root.model)
 
         mj_float_link_1 = mj_root.worldbody.find('body', 'float_link_1')
         self.assertIsNotNone(mj_float_link_1)
@@ -121,7 +118,6 @@ class ModelTest(unittest.TestCase):
 
         mj_root = add_model(self.mujoco, model)
         self.assertIsNotNone(mj_root)
-        self.assertEqual("test_model", mj_root.model)
 
         mj_base_link = mj_root.worldbody.find('body', 'base_link')
         self.assertIsNotNone(mj_base_link)

--- a/sdformat_to_mjcf/tests/test_sdf_kinematics.py
+++ b/sdformat_to_mjcf/tests/test_sdf_kinematics.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2022 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+import unittest
+
+import sdformat as sdf
+from sdformat_to_mjcf.sdf_kinematics import KinematicHierarchy
+
+JointType = sdf.Joint.JointType
+
+TEST_RESOURCES_DIR = pathlib.Path(__file__).resolve().parent / 'resources'
+
+
+class TreeTest(unittest.TestCase):
+
+    def load_sdf_file(self, file_name):
+        root = sdf.Root()
+        errors = root.load(file_name)
+        self.assertEqual(0, len(errors), errors)
+        return root
+
+    def test_hierarchy(self):
+        model_file = TEST_RESOURCES_DIR / "double_pendulum.sdf"
+        root = self.load_sdf_file(str(model_file))
+        self.assertIsNotNone(root.model())
+        kin_hierarchy = KinematicHierarchy(root.model())
+        self.assertEqual(1, len(kin_hierarchy.world_node.child_nodes))
+
+        base_node = kin_hierarchy.world_node.child_nodes[0]
+        self.assertEqual("base", base_node.link.name())
+        self.assertEqual(1, len(base_node.child_nodes))
+        self.assertEqual("fix_to_world", base_node.joint.name())
+        self.assertEqual(JointType.FIXED, base_node.joint.type())
+
+        upper_link_node = base_node.child_nodes[0]
+        self.assertEqual("upper_link", upper_link_node.link.name())
+        self.assertEqual(1, len(upper_link_node.child_nodes))
+        self.assertEqual("upper_joint", upper_link_node.joint.name())
+        self.assertEqual(JointType.REVOLUTE, upper_link_node.joint.type())
+
+        lower_link_node = upper_link_node.child_nodes[0]
+        self.assertEqual("lower_link", lower_link_node.link.name())
+        self.assertEqual(0, len(lower_link_node.child_nodes))
+        self.assertEqual("lower_joint", lower_link_node.joint.name())
+        self.assertEqual(JointType.REVOLUTE, lower_link_node.joint.type())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# 🎉 New feature

## Summary
Adds conversion for SDFormat models where the kinematic hierarchy is assumed to be a tree.

Needs #32 for tests to pass.

## Test it
Run unittests `test_add_model.py` and `test_sdf_kinematics.py`

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.