### PR TITLE
Fixed test name

### DIFF
--- a/sdformat_to_mjcf/tests/test_add_joint.py
+++ b/sdformat_to_mjcf/tests/test_add_joint.py
@@ -69,7 +69,7 @@ class JointTest(helpers.TestCase):
                          mj_joint.name)
         self.assertEqual("freejoint", mj_joint.tag)
 
-    def test_multilpe_free_joints(self):
+    def test_multiple_free_joints(self):
         mj_joint1 = add_joint(self.body, None)
         self.assertIsNotNone(mj_joint1)
         # Add another body with a free joint to worldbody


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>
# 🦟 Bug fix

## Summary

Fix test name. Related with this comment https://github.com/gazebosim/gz-mujoco/pull/32#pullrequestreview-977751117

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
