### PR TITLE
Support PYPI publishing in github actions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,34 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  push:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    # Prefer manual upload to https://github.com/pypa/gh-action-pypi-publish to
+    # avoid possible security flaws in the provisioning chain
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,5 +30,6 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
+        cd sdformat_mjcf
         python setup.py sdist bdist_wheel
         twine upload dist/*


### PR DESCRIPTION
This PR needs #39 before in order to have a main setup.py to call.

It basically setup a python environment with all the tools needed (particularly twine to make the upload to PYPI) and do the same steps that one can do it for uploading manually a release.

The PR reacts to the event of [creating a GitHub release ](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository). If we prefer to react to a string found in a git tag (something like the patter `release_`) we could use (insteda of push - release- types):
```yaml
on:
  push:
    tags:
    - 'release_*'
```

To finish the setup, we would need to add the credentials for the PYPI upload: `PYPI_USERNAME` and `PYPI_PASSWORD` with their correspondent values in https://github.com/gazebosim/gz-mujoco/settings/secrets/actions/new. I would recommend to create PYPI token and use it in `PYPI_PASSWORD`.

I've [run a test to check](https://github.com/gazebosim/gz-mujoco/runs/6530211248?check_suite_focus=true#step:5:186) that everything is fine until the point of the upload, that fails because of missing credentials. Seems fine.


