### PR TITLE
Used right enum namespace

### DIFF
--- a/mjcf_to_sdformat/mjcf_to_sdformat/converters/geometry.py
+++ b/mjcf_to_sdformat/mjcf_to_sdformat/converters/geometry.py
@@ -40,7 +40,7 @@ def mjcf_geom_to_sdf(geom):
         box = sdf.Box()
         box.set_size(su.list_to_vec3d(geom.size) * 2)
         sdf_geometry.set_box_shape(box)
-        sdf_geometry.set_type(sdf.Geometry.GeometryType.BOX)
+        sdf_geometry.set_type(sdf.GeometryType.BOX)
         # TODO(ahcorde): Add fromto
     elif geom.type == "capsule":
         capsule = sdf.Capsule()
@@ -53,7 +53,7 @@ def mjcf_geom_to_sdf(geom):
             length = v1.distance(v2)
             capsule.set_length(length)
         sdf_geometry.set_capsule_shape(capsule)
-        sdf_geometry.set_type(sdf.Geometry.GeometryType.CAPSULE)
+        sdf_geometry.set_type(sdf.GeometryType.CAPSULE)
     elif geom.type == "cylinder":
         cylinder = sdf.Cylinder()
         cylinder.set_radius(geom.size[0])
@@ -65,23 +65,23 @@ def mjcf_geom_to_sdf(geom):
             length = v1.distance(v2)
             cylinder.set_length(length)
         sdf_geometry.set_cylinder_shape(cylinder)
-        sdf_geometry.set_type(sdf.Geometry.GeometryType.CYLINDER)
+        sdf_geometry.set_type(sdf.GeometryType.CYLINDER)
     elif geom.type == "ellipsoid":
         ellipsoid = sdf.Ellipsoid()
         ellipsoid.set_radii(su.list_to_vec3d(geom.size))
         sdf_geometry.set_ellipsoid_shape(ellipsoid)
-        sdf_geometry.set_type(sdf.Geometry.GeometryType.ELLIPSOID)
+        sdf_geometry.set_type(sdf.GeometryType.ELLIPSOID)
         # TODO(ahcorde): Add fromto
     elif geom.type == "sphere":
         sphere = sdf.Sphere()
         sphere.set_radius(geom.size[0])
         sdf_geometry.set_sphere_shape(sphere)
-        sdf_geometry.set_type(sdf.Geometry.GeometryType.SPHERE)
+        sdf_geometry.set_type(sdf.GeometryType.SPHERE)
     elif geom.type == "plane":
         plane = sdf.Plane()
         plane.set_size(Vector2d(geom.size[0] * 2, geom.size[1] * 2))
         sdf_geometry.set_plane_shape(plane)
-        sdf_geometry.set_type(sdf.Geometry.GeometryType.PLANE)
+        sdf_geometry.set_type(sdf.GeometryType.PLANE)
     else:
         raise RuntimeError(
             f"Encountered unsupported shape type {geom.type}")

--- a/mjcf_to_sdformat/tests/test_add_mjcf_geometry_to_sdf.py
+++ b/mjcf_to_sdformat/tests/test_add_mjcf_geometry_to_sdf.py
@@ -23,8 +23,6 @@ from mjcf_to_sdformat.converters import geometry as geometry_conv
 
 import sdformat_mjcf_utils.sdf_utils as su
 
-GeometryType = sdf.Geometry.GeometryType
-
 
 class GeometryTest(unittest.TestCase):
 
@@ -37,7 +35,7 @@ class GeometryTest(unittest.TestCase):
                         size=[x_size, y_size, z_size])
         sdf_geom = geometry_conv.mjcf_geom_to_sdf(geom)
 
-        self.assertEqual(GeometryType.BOX, sdf_geom.type())
+        self.assertEqual(sdf.GeometryType.BOX, sdf_geom.type())
         self.assertNotEqual(None, sdf_geom.box_shape())
         self.assertEqual(Vector3d(x_size, y_size, z_size) * 2,
                          sdf_geom.box_shape().size())
@@ -51,7 +49,7 @@ class GeometryTest(unittest.TestCase):
         geom = body.add('geom', type="capsule", size=[radius, length])
         sdf_geom = geometry_conv.mjcf_geom_to_sdf(geom)
 
-        self.assertEqual(GeometryType.CAPSULE, sdf_geom.type())
+        self.assertEqual(sdf.GeometryType.CAPSULE, sdf_geom.type())
         self.assertNotEqual(None, sdf_geom.capsule_shape())
         self.assertEqual(radius, sdf_geom.capsule_shape().radius())
         self.assertEqual(length, sdf_geom.capsule_shape().length() / 2)
@@ -66,7 +64,7 @@ class GeometryTest(unittest.TestCase):
                         fromto=[0, 0, 0, 0, 0, 1])
         sdf_geom = geometry_conv.mjcf_geom_to_sdf(geom)
 
-        self.assertEqual(GeometryType.CAPSULE, sdf_geom.type())
+        self.assertEqual(sdf.GeometryType.CAPSULE, sdf_geom.type())
         self.assertNotEqual(None, sdf_geom.capsule_shape())
         self.assertEqual(radius, sdf_geom.capsule_shape().radius())
         self.assertEqual(length, sdf_geom.capsule_shape().length())
@@ -80,7 +78,7 @@ class GeometryTest(unittest.TestCase):
         geom = body.add('geom', type="cylinder", size=[radius, length])
         sdf_geom = geometry_conv.mjcf_geom_to_sdf(geom)
 
-        self.assertEqual(GeometryType.CYLINDER, sdf_geom.type())
+        self.assertEqual(sdf.GeometryType.CYLINDER, sdf_geom.type())
         self.assertNotEqual(None, sdf_geom.cylinder_shape())
         self.assertEqual(radius, sdf_geom.cylinder_shape().radius())
         self.assertEqual(length, sdf_geom.cylinder_shape().length() / 2)
@@ -95,7 +93,7 @@ class GeometryTest(unittest.TestCase):
                         fromto=[0, 0, 0, 0, 0, 1])
         sdf_geom = geometry_conv.mjcf_geom_to_sdf(geom)
 
-        self.assertEqual(GeometryType.CYLINDER, sdf_geom.type())
+        self.assertEqual(sdf.GeometryType.CYLINDER, sdf_geom.type())
         self.assertNotEqual(None, sdf_geom.cylinder_shape())
         self.assertEqual(radius, sdf_geom.cylinder_shape().radius())
         self.assertEqual(length, sdf_geom.cylinder_shape().length())
@@ -111,7 +109,7 @@ class GeometryTest(unittest.TestCase):
                         size=[x_radius, y_radius, z_radius])
         sdf_geom = geometry_conv.mjcf_geom_to_sdf(geom)
 
-        self.assertEqual(GeometryType.ELLIPSOID, sdf_geom.type())
+        self.assertEqual(sdf.GeometryType.ELLIPSOID, sdf_geom.type())
         self.assertNotEqual(None, sdf_geom.ellipsoid_shape())
         assert_allclose([x_radius, y_radius, z_radius],
                         su.vec3d_to_list(sdf_geom.ellipsoid_shape().radii()))
@@ -133,7 +131,7 @@ class GeometryTest(unittest.TestCase):
                         size=[x_size, y_size, 0.05])
         sdf_geom = geometry_conv.mjcf_geom_to_sdf(geom)
 
-        self.assertEqual(GeometryType.PLANE, sdf_geom.type())
+        self.assertEqual(sdf.GeometryType.PLANE, sdf_geom.type())
         self.assertNotEqual(None, sdf_geom.plane_shape())
         assert_allclose([x_size * 2, y_size * 2],
                         su.vec2d_to_list(sdf_geom.plane_shape().size()))
@@ -148,7 +146,7 @@ class GeometryTest(unittest.TestCase):
                         size=[radius])
         sdf_geom = geometry_conv.mjcf_geom_to_sdf(geom)
 
-        self.assertEqual(GeometryType.SPHERE, sdf_geom.type())
+        self.assertEqual(sdf.GeometryType.SPHERE, sdf_geom.type())
         self.assertNotEqual(None, sdf_geom.sphere_shape())
         self.assertEqual(radius, sdf_geom.sphere_shape().radius())
 
@@ -164,11 +162,11 @@ class VisualTest(unittest.TestCase):
                         size=[radius])
         sdf_visual = geometry_conv.mjcf_visual_to_sdf(geom)
 
-        self.assertEqual(GeometryType.SPHERE, sdf_visual.geometry().type())
+        self.assertEqual(sdf.GeometryType.SPHERE, sdf_visual.geometry().type())
         self.assertNotEqual(None, sdf_visual.geometry())
 
         sdf_geom = sdf_visual.geometry()
-        self.assertEqual(GeometryType.SPHERE, sdf_geom.type())
+        self.assertEqual(sdf.GeometryType.SPHERE, sdf_geom.type())
         self.assertNotEqual(None, sdf_geom.sphere_shape())
         self.assertEqual(radius, sdf_geom.sphere_shape().radius())
 
@@ -184,11 +182,11 @@ class CollisionTest(unittest.TestCase):
                         size=[radius])
         sdf_col = geometry_conv.mjcf_collision_to_sdf(geom)
 
-        self.assertEqual(GeometryType.SPHERE, sdf_col.geometry().type())
+        self.assertEqual(sdf.GeometryType.SPHERE, sdf_col.geometry().type())
         self.assertNotEqual(None, sdf_col.geometry())
 
         sdf_geom = sdf_col.geometry()
-        self.assertEqual(GeometryType.SPHERE, sdf_geom.type())
+        self.assertEqual(sdf.GeometryType.SPHERE, sdf_geom.type())
         self.assertNotEqual(None, sdf_geom.sphere_shape())
         self.assertEqual(radius, sdf_geom.sphere_shape().radius())
 

--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/geometry.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/geometry.py
@@ -16,10 +16,7 @@
 
 import os
 
-import sdformat as sdf
 import sdformat_mjcf_utils.sdf_utils as su
-
-GeometryType = sdf.Geometry.GeometryType
 
 COLLISION_GEOM_GROUP = 3
 VISUAL_GEOM_GROUP = 0

--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/joint.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/joint.py
@@ -20,8 +20,6 @@ import sdformat as sdf
 
 import sdformat_mjcf_utils.sdf_utils as su
 
-JointType = sdf.Joint.JointType
-
 JOINT_DEFAULT_UPPER_LIMIT = 1e16
 JOINT_DEFAULT_LOWER_LIMIT = -1e16
 JOINT_DEFAULT_DAMPING = 0.0
@@ -68,10 +66,12 @@ def add_joint(body, joint):
     if joint is None:
         return body.add("freejoint",
                         name=su.prefix_name(body.name, "freejoint"))
-    elif joint.type() == JointType.FIXED:
+    elif joint.type() == sdf.JointType.FIXED:
         return None
     elif joint.type() in [
-            JointType.CONTINUOUS, JointType.REVOLUTE, JointType.PRISMATIC
+            sdf.JointType.CONTINUOUS,
+            sdf.JointType.REVOLUTE,
+            sdf.JointType.PRISMATIC
     ]:
         pose = su.graph_resolver.resolve_pose(joint.semantic_pose())
         mjcf_joint = body.add("joint", name=joint.name())
@@ -106,10 +106,10 @@ def add_joint(body, joint):
                 mjcf_joint.springref = convert_value(
                     joint_axis.spring_reference())
 
-        if joint.type() in [JointType.CONTINUOUS, JointType.REVOLUTE]:
+        if joint.type() in [sdf.JointType.CONTINUOUS, sdf.JointType.REVOLUTE]:
             mjcf_joint.type = "hinge"
             add_dynamics(math.degrees)
-            if joint.type() == JointType.REVOLUTE:
+            if joint.type() == sdf.JointType.REVOLUTE:
                 add_limits(math.degrees)
         else:
             mjcf_joint.type = "slide"
@@ -119,7 +119,7 @@ def add_joint(body, joint):
         mjcf_joint.axis = _compute_joint_axis(joint_axis, pose)
 
         return mjcf_joint
-    elif joint.type() == JointType.BALL:
+    elif joint.type() == sdf.JointType.BALL:
         pose = su.graph_resolver.resolve_pose(joint.semantic_pose())
         mjcf_joint = body.add("joint", name=joint.name())
         mjcf_joint.pos = su.vec3d_to_list(pose.pos())

--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/light.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/light.py
@@ -35,7 +35,7 @@ def add_light(body, light):
     light = body.add("light",
                      name=light.name(),
                      pos=su.vec3d_to_list(pose.pos()),
-                     directional=sdf.Light.LightType.DIRECTIONAL == type,
+                     directional=sdf.LightType.DIRECTIONAL == type,
                      castshadow=light.cast_shadows(),
                      attenuation=[light.constant_attenuation_factor(),
                                   light.linear_attenuation_factor(),

--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/material.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/material.py
@@ -17,6 +17,7 @@
 from ignition.math import clamp
 
 from sdformat import Pbr, PbrWorkflow, Material  # noqa: F401
+import sdformat as sdf
 
 import os
 
@@ -40,7 +41,7 @@ def add_material(geom, material):
     asset = geom.root.asset
     r_mat = None
     if pbr is not None:
-        workflow = pbr.workflow(PbrWorkflow.PbrWorkflowType.METAL)
+        workflow = pbr.workflow(sdf.PbrWorkflowType.METAL)
         if workflow is not None:
             if workflow.albedo_map():
                 f_without_extension, extension = os.path.splitext(

--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/model.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/model.py
@@ -16,8 +16,9 @@ from dm_control import mjcf
 
 from sdformat_to_mjcf.sdf_kinematics import KinematicHierarchy
 from sdformat_to_mjcf.converters.link import add_link
-from sdformat_to_mjcf.converters.joint import add_joint, JointType
+from sdformat_to_mjcf.converters.joint import add_joint
 from sdformat_mjcf_utils.sdf_utils import graph_resolver
+import sdformat as sdf
 
 
 def add_model(mjcf_root, model):
@@ -55,7 +56,7 @@ def add_model(mjcf_root, model):
         if node.joint is None:
             should_add_exclusions = False
         else:
-            is_fixed_joint = node.joint.type() == JointType.FIXED
+            is_fixed_joint = node.joint.type() == sdf.JointType.FIXED
             is_body_world = body.tag == mjcf.constants.WORLDBODY
             should_add_exclusions = is_fixed_joint and is_body_world
 

--- a/sdformat_to_mjcf/tests/test_add_geometry.py
+++ b/sdformat_to_mjcf/tests/test_add_geometry.py
@@ -26,9 +26,6 @@ from tests import helpers
 from sdformat_to_mjcf.converters import geometry as geometry_conv
 
 
-GeometryType = sdf.Geometry.GeometryType
-
-
 class GeometryTest(helpers.TestCase):
 
     test_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)
@@ -41,7 +38,7 @@ class GeometryTest(helpers.TestCase):
         box.set_size(Vector3d(x_size, y_size, z_size))
         geometry = sdf.Geometry()
         geometry.set_box_shape(box)
-        geometry.set_type(GeometryType.BOX)
+        geometry.set_type(sdf.GeometryType.BOX)
 
         mujoco = mjcf.RootElement(model="test")
         body = mujoco.worldbody.add('body')
@@ -62,7 +59,7 @@ class GeometryTest(helpers.TestCase):
 
         geometry = sdf.Geometry()
         geometry.set_capsule_shape(capsule)
-        geometry.set_type(GeometryType.CAPSULE)
+        geometry.set_type(sdf.GeometryType.CAPSULE)
 
         mujoco = mjcf.RootElement(model="test")
         body = mujoco.worldbody.add('body')
@@ -83,7 +80,7 @@ class GeometryTest(helpers.TestCase):
 
         geometry = sdf.Geometry()
         geometry.set_cylinder_shape(cylinder)
-        geometry.set_type(GeometryType.CYLINDER)
+        geometry.set_type(sdf.GeometryType.CYLINDER)
 
         mujoco = mjcf.RootElement(model="test")
         body = mujoco.worldbody.add('body')
@@ -104,7 +101,7 @@ class GeometryTest(helpers.TestCase):
 
         geometry = sdf.Geometry()
         geometry.set_ellipsoid_shape(ellipsoid)
-        geometry.set_type(GeometryType.ELLIPSOID)
+        geometry.set_type(sdf.GeometryType.ELLIPSOID)
 
         mujoco = mjcf.RootElement(model="test")
         body = mujoco.worldbody.add('body')
@@ -128,7 +125,7 @@ class GeometryTest(helpers.TestCase):
 
         geometry = sdf.Geometry()
         geometry.set_mesh_shape(mesh)
-        geometry.set_type(GeometryType.MESH)
+        geometry.set_type(sdf.GeometryType.MESH)
 
         mujoco = mjcf.RootElement(model="test")
         body = mujoco.worldbody.add('body')
@@ -149,7 +146,7 @@ class GeometryTest(helpers.TestCase):
 
         geometry = sdf.Geometry()
         geometry.set_plane_shape(plane)
-        geometry.set_type(GeometryType.PLANE)
+        geometry.set_type(sdf.GeometryType.PLANE)
 
         mujoco = mjcf.RootElement(model="test")
         body = mujoco.worldbody.add('body')
@@ -168,7 +165,7 @@ class GeometryTest(helpers.TestCase):
 
         geometry = sdf.Geometry()
         geometry.set_sphere_shape(sphere)
-        geometry.set_type(GeometryType.SPHERE)
+        geometry.set_type(sdf.GeometryType.SPHERE)
 
         mujoco = mjcf.RootElement(model="test")
         body = mujoco.worldbody.add('body')
@@ -190,7 +187,7 @@ class CollisionTest(helpers.TestCase):
 
         geometry = sdf.Geometry()
         geometry.set_box_shape(sdf.Box())
-        geometry.set_type(GeometryType.BOX)
+        geometry.set_type(sdf.GeometryType.BOX)
         collision.set_geometry(geometry)
 
         mujoco = mjcf.RootElement(model="test")
@@ -211,7 +208,7 @@ class VisualTest(helpers.TestCase):
 
         geometry = sdf.Geometry()
         geometry.set_box_shape(sdf.Box())
-        geometry.set_type(GeometryType.BOX)
+        geometry.set_type(sdf.GeometryType.BOX)
         visual.set_geometry(geometry)
 
         mujoco = mjcf.RootElement(model="test")

--- a/sdformat_to_mjcf/tests/test_add_joint.py
+++ b/sdformat_to_mjcf/tests/test_add_joint.py
@@ -20,7 +20,6 @@ import sdformat as sdf
 from ignition.math import Pose3d, Vector3d
 from dm_control import mjcf
 
-from sdformat_to_mjcf.converters.joint import JointType
 from sdformat_to_mjcf.converters.joint import add_joint
 import sdformat_mjcf_utils.sdf_utils as su
 from tests import helpers
@@ -79,13 +78,13 @@ class JointTest(helpers.TestCase):
 
     def test_fixed_joint(self):
         joint = sdf.Joint()
-        joint.set_type(JointType.FIXED)
+        joint.set_type(sdf.JointType.FIXED)
         mj_joint = add_joint(self.body, joint)
         self.assertIsNone(mj_joint)
 
     def test_revolute_joint(self):
         joint = self.create_sdf_joint("joint1",
-                                      JointType.REVOLUTE,
+                                      sdf.JointType.REVOLUTE,
                                       self.test_pose,
                                       xyz=[1, 0, 0])
 
@@ -102,7 +101,7 @@ class JointTest(helpers.TestCase):
 
     def test_revolute_joint_with_limits(self):
         joint = self.create_sdf_joint("joint1",
-                                      JointType.REVOLUTE,
+                                      sdf.JointType.REVOLUTE,
                                       self.test_pose,
                                       xyz=[1, 0, 0],
                                       limits=(-pi / 4, pi / 2))
@@ -119,7 +118,7 @@ class JointTest(helpers.TestCase):
             'spring_reference': pi / 6
         }
         joint = self.create_sdf_joint("joint1",
-                                      JointType.REVOLUTE,
+                                      sdf.JointType.REVOLUTE,
                                       self.test_pose,
                                       xyz=[1, 0, 0],
                                       dynamics=joint_dynamics)
@@ -133,7 +132,7 @@ class JointTest(helpers.TestCase):
 
     def test_continuous_joint(self):
         joint = self.create_sdf_joint("joint1",
-                                      JointType.CONTINUOUS,
+                                      sdf.JointType.CONTINUOUS,
                                       self.test_pose,
                                       xyz=[1, 0, 0],
                                       limits=(-pi / 4, pi / 2))
@@ -158,7 +157,7 @@ class JointTest(helpers.TestCase):
             'spring_reference': pi / 6
         }
         joint = self.create_sdf_joint("joint1",
-                                      JointType.CONTINUOUS,
+                                      sdf.JointType.CONTINUOUS,
                                       self.test_pose,
                                       xyz=[1, 0, 0],
                                       dynamics=joint_dynamics)
@@ -172,7 +171,7 @@ class JointTest(helpers.TestCase):
 
     def test_prismatic_joint(self):
         joint = self.create_sdf_joint("joint1",
-                                      JointType.PRISMATIC,
+                                      sdf.JointType.PRISMATIC,
                                       self.test_pose,
                                       xyz=[1, 0, 0])
 
@@ -188,7 +187,7 @@ class JointTest(helpers.TestCase):
 
     def test_prismatic_joint_with_limits(self):
         joint = self.create_sdf_joint("joint1",
-                                      JointType.PRISMATIC,
+                                      sdf.JointType.PRISMATIC,
                                       self.test_pose,
                                       xyz=[1, 0, 0],
                                       limits=(-5, 10))
@@ -205,7 +204,7 @@ class JointTest(helpers.TestCase):
             'spring_reference': 0.4
         }
         joint = self.create_sdf_joint("joint1",
-                                      JointType.PRISMATIC,
+                                      sdf.JointType.PRISMATIC,
                                       self.test_pose,
                                       xyz=[1, 0, 0],
                                       dynamics=joint_dynamics)
@@ -218,7 +217,7 @@ class JointTest(helpers.TestCase):
 
     def test_ball_joint(self):
         joint = self.create_sdf_joint("joint1",
-                                      JointType.BALL,
+                                      sdf.JointType.BALL,
                                       self.test_pose)
 
         mj_joint = add_joint(self.body, joint)

--- a/sdformat_to_mjcf/tests/test_add_light.py
+++ b/sdformat_to_mjcf/tests/test_add_light.py
@@ -41,7 +41,7 @@ class LightTest(helpers.TestCase):
     def test_light(self):
         light = sdf.Light()
         light.set_name("light")
-        light.set_type(sdf.Light.LightType.DIRECTIONAL)
+        light.set_type(sdf.LightType.DIRECTIONAL)
         light.set_raw_pose(self.test_pose)
         light.set_cast_shadows(True)
         light.set_diffuse(Color(0.4, 0.5, 0.6, 1.0))
@@ -57,7 +57,7 @@ class LightTest(helpers.TestCase):
         self.assertNotEqual(light_mjcf, None)
         self.assertEqual(light_mjcf.name, light.name())
         self.assertEqual(bool(light_mjcf.directional),
-                         light.type() == sdf.Light.LightType.DIRECTIONAL)
+                         light.type() == sdf.LightType.DIRECTIONAL)
         self.assertEqual(bool(light_mjcf.castshadow), light.cast_shadows())
         assert_allclose(self.expected_pos, light_mjcf.pos)
         assert_allclose([light.constant_attenuation_factor(),
@@ -86,7 +86,7 @@ class LightTest(helpers.TestCase):
 
         light = sdf.Light()
         light.set_name("light")
-        light.set_type(sdf.Light.LightType.DIRECTIONAL)
+        light.set_type(sdf.LightType.DIRECTIONAL)
         light.set_raw_pose(self.test_pose)
         light.set_cast_shadows(True)
         light.set_diffuse(Color(0.4, 0.5, 0.6, 1.0))
@@ -104,7 +104,7 @@ class LightTest(helpers.TestCase):
         self.assertNotEqual(body_mjcf.light[0], None)
         self.assertEqual(body_mjcf.light[0].name, light.name())
         self.assertEqual(bool(body_mjcf.light[0].directional),
-                         light.type() == sdf.Light.LightType.DIRECTIONAL)
+                         light.type() == sdf.LightType.DIRECTIONAL)
         self.assertEqual(bool(body_mjcf.light[0].castshadow),
                          light.cast_shadows())
         assert_allclose(self.expected_pos, body_mjcf.light[0].pos)

--- a/sdformat_to_mjcf/tests/test_add_link.py
+++ b/sdformat_to_mjcf/tests/test_add_link.py
@@ -24,8 +24,6 @@ from sdformat_to_mjcf.converters.link import add_link
 import sdformat_mjcf_utils.sdf_utils as su
 from tests import helpers
 
-GeometryType = sdf.Geometry.GeometryType
-
 
 class LinkTest(helpers.TestCase):
     test_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)
@@ -51,7 +49,7 @@ class LinkTest(helpers.TestCase):
         item.set_name(name)
         geometry = sdf.Geometry()
         geometry.set_box_shape(sdf.Box())
-        geometry.set_type(GeometryType.BOX)
+        geometry.set_type(sdf.GeometryType.BOX)
         item.set_geometry(geometry)
         return item
 
@@ -124,7 +122,7 @@ class LinkTest(helpers.TestCase):
 
         geometry = sdf.Geometry()
         geometry.set_box_shape(sdf.Box())
-        geometry.set_type(GeometryType.BOX)
+        geometry.set_type(sdf.GeometryType.BOX)
         visual.set_geometry(geometry)
         collision.set_geometry(geometry)
 

--- a/sdformat_to_mjcf/tests/test_add_material.py
+++ b/sdformat_to_mjcf/tests/test_add_material.py
@@ -30,7 +30,7 @@ class MaterialTest(helpers.TestCase):
     def test_material_pbr(self):
         pbr = sdf.Pbr()
         workflow = sdf.PbrWorkflow()
-        workflow.set_type(sdf.PbrWorkflow.PbrWorkflowType.METAL)
+        workflow.set_type(sdf.PbrWorkflowType.METAL)
         workflow.set_albedo_map(os.path.join(
                                 os.path.dirname(os.path.abspath(__file__)),
                                 "resources/box_obj/textures/albedo_map.png"))
@@ -67,7 +67,7 @@ class MaterialTest(helpers.TestCase):
     def test_material_pbr_bad_extension(self):
         pbr = sdf.Pbr()
         workflow = sdf.PbrWorkflow()
-        workflow.set_type(sdf.PbrWorkflow.PbrWorkflowType.METAL)
+        workflow.set_type(sdf.PbrWorkflowType.METAL)
         workflow.set_albedo_map(os.path.join(
                                 os.path.dirname(os.path.abspath(__file__)),
                                 "resources/box_obj/textures/albedo_map"))

--- a/sdformat_to_mjcf/tests/test_add_model.py
+++ b/sdformat_to_mjcf/tests/test_add_model.py
@@ -24,9 +24,6 @@ from sdformat_to_mjcf.converters.model import add_model
 import sdformat_mjcf_utils.sdf_utils as su
 from tests import helpers
 
-GeometryType = sdf.Geometry.GeometryType
-JointType = sdf.Joint.JointType
-
 
 class ModelTest(helpers.TestCase):
     test_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)
@@ -113,7 +110,7 @@ class ModelTest(helpers.TestCase):
 
         joint = sdf.Joint()
         joint.set_name("joint")
-        joint.set_type(JointType.FIXED)
+        joint.set_type(sdf.JointType.FIXED)
         joint.set_parent_link_name("base_link")
         joint.set_child_link_name("upper_link")
         model.add_joint(joint)

--- a/sdformat_to_mjcf/tests/test_add_root.py
+++ b/sdformat_to_mjcf/tests/test_add_root.py
@@ -22,9 +22,6 @@ from dm_control import mjcf
 from sdformat_to_mjcf.converters.root import add_root
 from tests import helpers
 
-GeometryType = sdf.Geometry.GeometryType
-JointType = sdf.Joint.JointType
-
 
 class RootTest(helpers.TestCase):
     test_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)

--- a/sdformat_to_mjcf/tests/test_add_world.py
+++ b/sdformat_to_mjcf/tests/test_add_world.py
@@ -23,8 +23,6 @@ from sdformat_to_mjcf.converters.world import add_world
 from tests import helpers
 import sdformat_mjcf_utils.sdf_utils as su
 
-GeometryType = sdf.Geometry.GeometryType
-
 
 class WorldTest(helpers.TestCase):
 

--- a/sdformat_to_mjcf/tests/test_sdf_kinematics.py
+++ b/sdformat_to_mjcf/tests/test_sdf_kinematics.py
@@ -18,8 +18,6 @@ import sdformat as sdf
 from sdformat_to_mjcf.sdf_kinematics import KinematicHierarchy
 from tests.helpers import TEST_RESOURCES_DIR
 
-JointType = sdf.Joint.JointType
-
 
 class TreeTest(unittest.TestCase):
 
@@ -40,19 +38,19 @@ class TreeTest(unittest.TestCase):
         self.assertEqual("base", base_node.link.name())
         self.assertEqual(1, len(base_node.child_nodes))
         self.assertEqual("fix_to_world", base_node.joint.name())
-        self.assertEqual(JointType.FIXED, base_node.joint.type())
+        self.assertEqual(sdf.JointType.FIXED, base_node.joint.type())
 
         upper_link_node = base_node.child_nodes[0]
         self.assertEqual("upper_link", upper_link_node.link.name())
         self.assertEqual(1, len(upper_link_node.child_nodes))
         self.assertEqual("upper_joint", upper_link_node.joint.name())
-        self.assertEqual(JointType.REVOLUTE, upper_link_node.joint.type())
+        self.assertEqual(sdf.JointType.REVOLUTE, upper_link_node.joint.type())
 
         lower_link_node = upper_link_node.child_nodes[0]
         self.assertEqual("lower_link", lower_link_node.link.name())
         self.assertEqual(0, len(lower_link_node.child_nodes))
         self.assertEqual("lower_joint", lower_link_node.joint.name())
-        self.assertEqual(JointType.REVOLUTE, lower_link_node.joint.type())
+        self.assertEqual(sdf.JointType.REVOLUTE, lower_link_node.joint.type())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

This PR https://github.com/gazebosim/sdformat/pull/1029 in SDFormat changes the enum namespace.  This PR fixed the enums.

We need to wait for a nightly release

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
