### PR TITLE
SDFormat to MJCF: Add conversion for IMU Sensor

### DIFF
--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/link.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/link.py
@@ -15,10 +15,11 @@
 from sdformat_to_mjcf.converters.geometry import add_collision, add_visual
 from sdformat_to_mjcf.converters.light import add_light
 from sdformat_to_mjcf.converters.material import add_material
+from sdformat_to_mjcf.converters.sensor import add_sensor
 import sdformat_mjcf_utils.sdf_utils as su
 
 
-def add_link(body, link, parent_name="world", model_name="model"):
+def add_link(body, link, parent_name="world"):
     """
     Converts a link from SDFormat to MJCF and add it to the given
     body/worldbody.
@@ -92,5 +93,10 @@ def add_link(body, link, parent_name="world", model_name="model"):
         light = link.light_by_index(li)
         if light is not None:
             add_light(body, light)
+
+    for si in range(link.sensor_count()):
+        sensor = link.sensor_by_index(si)
+        if sensor is not None:
+            add_sensor(body, sensor)
 
     return body

--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/model.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/model.py
@@ -39,8 +39,7 @@ def add_model(mjcf_root, model):
     def convert_node(body, node):
         child_body = add_link(body,
                               node.link,
-                              node.parent_node.link.name(),
-                              model.name())
+                              node.parent_node.link.name())
 
         add_joint(child_body, node.joint)
         # Geoms added to bodies attached to the worldbody without a

--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/sensor.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/sensor.py
@@ -1,0 +1,114 @@
+# Copyright (C) 2022 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sdformat_mjcf_utils.sdf_utils as su
+
+
+def add_sensor(body, sensor):
+    """
+    Converts a sensor from SDFormat to MJCF and add it to the given
+    body.
+
+    :param mjcf.Element body: The MJCF body to which the sensor is added.
+    :param sdformat.Sensor sensor: The SDFormat sensor to be converted.
+    :return: One or more of the newly created MJCF sensors.
+    :rtype: [mjcf.Element]
+    """
+    sem_pose = sensor.semantic_pose()
+    pose = su.graph_resolver.resolve_pose(sem_pose)
+
+    # Creates a site inside the body with the same name as sensor. This site
+    # will be used to attach the actual sensor to the body.
+    site_unique_name = su.find_unique_name(body, "site", sensor.name())
+    body.add("site",
+             name=site_unique_name,
+             pos=su.vec3d_to_list(pose.pos()),
+             euler=su.quat_to_euler_list(pose.rot()))
+
+    if sensor.imu_sensor() is not None:
+        return _add_imu(body.root.sensor, sensor.imu_sensor(),
+                        site_unique_name)
+
+
+def _check_noise_equality(noises):
+    """
+    Check that all noise parameters are identical
+    :param [sdformat.Noise] noises: Noise parameters to check
+    :return: True if all noise parameters are equal to each other.
+    :rtype: bool
+    """
+    assert len(noises) > 0
+    first_item = noises[0]
+    return all(x == first_item for x in noises)
+
+
+def _add_imu(sensor, imu, sensor_name):
+    """
+    Converts an IMU sensor from SDFormat to MJCF and add it to the given
+    MJCF sensor.
+
+    :param mjcf.Element sensor: The MJCF sensor to which the IMU is added.
+    :param sdformat.IMU imu: The SDFormat IMU Sensor to be converted.
+    :param str sensor_name: The Name of the SDFormat <sensor> element that
+    contains the IMU.
+    :return: Converted accelerometer and gyro elements.
+    :rtype: [mjcf.Element]
+    """
+
+    # The following elements in <imu> are not currently supported.
+    # - <orientation_reference_frame>
+    # - <enable_orientation>
+    #
+    # For noise parameters, only the <stddev> is suported.
+    # TODO (azeey) Warn about unsupported elements in <imu>
+    accel_unique_name = su.find_unique_name(sensor, "sensor",
+                                            f"accelerometer_{sensor_name}")
+    gyro_unique_name = su.find_unique_name(sensor, "sensor",
+                                           f"gyro_{sensor_name}")
+
+    accel = sensor.add("accelerometer",
+                       site=sensor_name,
+                       name=accel_unique_name)
+
+    # TODO (azeey) Warn about unsupported noise parameters
+    accel_noises = [
+        imu.linear_acceleration_x_noise(),
+        imu.linear_acceleration_y_noise(),
+        imu.linear_acceleration_z_noise()
+    ]
+    # Check that all the noise parameters are the same for x, y, z axes.
+    if not _check_noise_equality(accel_noises):
+        logging.warning(
+            "Noise parameter mismatch for linear_acceleration of "
+            f"IMU named {sensor_name}. Conversion is supported only if the "
+            "noise parameters are identical.")
+    else:
+        accel.noise = accel_noises[0].std_dev()
+
+    gyro = sensor.add("gyro", site=sensor_name, name=gyro_unique_name)
+    gyro_noises = [
+        imu.angular_velocity_x_noise(),
+        imu.angular_velocity_y_noise(),
+        imu.angular_velocity_z_noise()
+    ]
+    if not _check_noise_equality(gyro_noises):
+        logging.warning(
+            "Noise parameter mismatch for angular_velocity of "
+            f"IMU named {sensor_name}. Conversion is supported only if the "
+            "noise parameters are identical.")
+    else:
+        gyro.noise = gyro_noises[0].std_dev()
+
+    return [accel, gyro]

--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/sensor.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/sensor.py
@@ -23,7 +23,8 @@ def add_sensor(body, sensor):
 
     :param mjcf.Element body: The MJCF body to which the sensor is added.
     :param sdformat.Sensor sensor: The SDFormat sensor to be converted.
-    :return: One or more of the newly created MJCF sensors.
+    :return: One or more of the newly created MJCF sensors. None if there are
+    no supported sensors to be converted.
     :rtype: [mjcf.Element]
     """
     sem_pose = sensor.semantic_pose()

--- a/sdformat_to_mjcf/tests/test_add_light.py
+++ b/sdformat_to_mjcf/tests/test_add_light.py
@@ -99,7 +99,7 @@ class LightTest(helpers.TestCase):
 
         link.add_light(light)
 
-        body_mjcf = add_link(self.body, link, model_name="light_model")
+        body_mjcf = add_link(self.body, link)
 
         self.assertNotEqual(body_mjcf.light[0], None)
         self.assertEqual(body_mjcf.light[0].name, light.name())

--- a/sdformat_to_mjcf/tests/test_add_link.py
+++ b/sdformat_to_mjcf/tests/test_add_link.py
@@ -56,7 +56,7 @@ class LinkTest(helpers.TestCase):
         link = sdf.Link()
         link.set_name("base_link")
         link.set_raw_pose(self.test_pose)
-        mj_body = add_link(self.body, link, model_name="base_model")
+        mj_body = add_link(self.body, link)
         self.assertIsNotNone(mj_body)
         assert_allclose(self.expected_pos, mj_body.pos)
         assert_allclose(self.expected_euler, mj_body.euler)
@@ -79,7 +79,7 @@ class LinkTest(helpers.TestCase):
             MassMatrix3d(384, Vector3d(544, 2624, 3104), Vector3d.ZERO),
             self.test_pose)
         link.set_inertial(inertial)
-        mj_body = add_link(self.body, link, model_name="base_model")
+        mj_body = add_link(self.body, link)
         self.assertIsNotNone(mj_body)
         assert_allclose((2604, 2604, 1064, -500, 260 * sqrt(6), 260 * sqrt(6)),
                         mj_body.inertial.fullinertia)
@@ -91,12 +91,12 @@ class LinkTest(helpers.TestCase):
         link1 = sdf.Link()
         link1.set_name("base_link")
         link1.set_raw_pose(Pose3d(-1, -2, -3, 0, 0, 0))
-        mj_body1 = add_link(self.body, link1, model_name="base_model")
+        mj_body1 = add_link(self.body, link1)
 
         link2 = sdf.Link()
         link2.set_name("lower_link")
         link2.set_raw_pose(self.test_pose)
-        mj_body2 = add_link(mj_body1, link2, model_name="base_link")
+        mj_body2 = add_link(mj_body1, link2)
 
         self.assertIsNotNone(mj_body2)
         assert_allclose(self.expected_pos, mj_body2.pos)
@@ -128,7 +128,7 @@ class LinkTest(helpers.TestCase):
         link.add_visual(visual)
         link.add_collision(collision)
 
-        mj_body = add_link(self.body, link, model_name="base_model")
+        mj_body = add_link(self.body, link)
         self.assertIsNotNone(mj_body)
         assert_allclose(self.expected_pos, mj_body.pos)
         assert_allclose(self.expected_euler, mj_body.euler)
@@ -150,8 +150,8 @@ class LinkTest(helpers.TestCase):
         link2 = sdf.Link()
         link2.set_name("link2")
         link2.add_collision(c1)
-        mj_body1 = add_link(self.body, link1, model_name="base_model")
-        mj_body2 = add_link(self.body, link2, model_name="base_model")
+        mj_body1 = add_link(self.body, link1)
+        mj_body2 = add_link(self.body, link2)
         self.assertIsNotNone(mj_body1)
         self.assertIsNotNone(mj_body2)
 
@@ -163,10 +163,28 @@ class LinkTest(helpers.TestCase):
         link2 = sdf.Link()
         link2.set_name("link2")
         link2.add_visual(v1)
-        mj_body1 = add_link(self.body, link1, model_name="base_model")
-        mj_body2 = add_link(self.body, link2, model_name="base_model")
+        mj_body1 = add_link(self.body, link1)
+        mj_body2 = add_link(self.body, link2)
         self.assertIsNotNone(mj_body1)
         self.assertIsNotNone(mj_body2)
+
+    def test_imu_sensor(self):
+        link = sdf.Link()
+        link.set_name("base_link")
+        sensor = sdf.Sensor()
+        sensor.set_name("imu_sensor")
+        sensor.set_type(sdf.Sensortype.IMU)
+        sensor.set_raw_pose(self.test_pose)
+        imu = sdf.IMU()
+        sensor.set_imu_sensor(imu)
+        link.add_sensor(sensor)
+        mj_body = add_link(self.body, link)
+        self.assertIsNotNone(mj_body)
+        self.assertIsNotNone(self.mujoco.sensor)
+        mjcf_accels = self.mujoco.sensor.get_children("accelerometer")
+        self.assertEqual(1, len(mjcf_accels))
+        mjcf_gyros = self.mujoco.sensor.get_children("gyro")
+        self.assertEqual(1, len(mjcf_gyros))
 
 
 if __name__ == "__main__":

--- a/sdformat_to_mjcf/tests/test_add_sensor.py
+++ b/sdformat_to_mjcf/tests/test_add_sensor.py
@@ -1,0 +1,144 @@
+# Copyright (C) 2022 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from numpy.testing import assert_allclose
+from math import pi
+
+import sdformat as sdf
+from ignition.math import Pose3d
+from dm_control import mjcf
+
+from sdformat_to_mjcf.converters.sensor import add_sensor
+from tests import helpers
+
+
+class ImuSensorTest(helpers.TestCase):
+    test_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)
+    expected_pos = [1.0, 2.0, 3.0]
+    expected_euler = [90.0, 60.0, 45.0]
+
+    def setUp(self):
+        self.mujoco = mjcf.RootElement(model="test")
+        self.body = self.mujoco.worldbody.add("body", name="test_body")
+        self.sensor = sdf.Sensor()
+        self.sensor.set_name("imu_sensor")
+        self.sensor.set_type(sdf.Sensortype.IMU)
+        self.sensor.set_raw_pose(self.test_pose)
+
+    def test_default(self):
+        imu = sdf.IMU()
+        self.sensor.set_imu_sensor(imu)
+        mjcf_sensors = add_sensor(self.body, self.sensor)
+
+        self.assertIsNotNone(mjcf_sensors)
+        self.assertEqual(2, len(mjcf_sensors))
+        self.assertIsNotNone(self.mujoco.sensor)
+
+        mjcf_accels = self.mujoco.sensor.get_children("accelerometer")
+        self.assertEqual(1, len(mjcf_accels))
+        mjcf_gyros = self.mujoco.sensor.get_children("gyro")
+        self.assertEqual(1, len(mjcf_gyros))
+
+        sensor_sites = self.body.get_children("site")
+        self.assertEqual(1, len(sensor_sites))
+        self.assertEqual(self.sensor.name(), sensor_sites[0].name)
+        assert_allclose(self.expected_pos, sensor_sites[0].pos)
+        assert_allclose(self.expected_euler, sensor_sites[0].euler)
+
+        mjcf_accel, mjcf_gyro = mjcf_sensors
+        self.assertAlmostEqual(f"accelerometer_{self.sensor.name()}",
+                               mjcf_accel.name)
+        self.assertAlmostEqual(self.sensor.name(), mjcf_accel.site)
+
+        self.assertAlmostEqual(f"gyro_{self.sensor.name()}", mjcf_gyro.name)
+        self.assertAlmostEqual(self.sensor.name(), mjcf_gyro.site)
+
+    def test_noise(self):
+        imu = sdf.IMU()
+        accel_noise = sdf.Noise()
+        accel_noise.set_type(sdf.NoiseType.GAUSSIAN)
+        accel_noise.set_std_dev(0.2)
+
+        gyro_noise = sdf.Noise()
+        gyro_noise.set_type(sdf.NoiseType.GAUSSIAN)
+        gyro_noise.set_std_dev(0.02)
+
+        imu.set_linear_acceleration_x_noise(accel_noise)
+        imu.set_linear_acceleration_y_noise(accel_noise)
+        imu.set_linear_acceleration_z_noise(accel_noise)
+
+        imu.set_angular_velocity_x_noise(gyro_noise)
+        imu.set_angular_velocity_y_noise(gyro_noise)
+        imu.set_angular_velocity_z_noise(gyro_noise)
+        self.sensor.set_imu_sensor(imu)
+        mjcf_sensors = add_sensor(self.body, self.sensor)
+
+        self.assertIsNotNone(mjcf_sensors)
+        self.assertEqual(2, len(mjcf_sensors))
+        self.assertIsNotNone(self.mujoco.sensor)
+
+        mjcf_accels = self.mujoco.sensor.get_children("accelerometer")
+        self.assertEqual(1, len(mjcf_accels))
+        mjcf_gyros = self.mujoco.sensor.get_children("gyro")
+        self.assertEqual(1, len(mjcf_gyros))
+
+        sensor_sites = self.body.get_children("site")
+        self.assertEqual(1, len(sensor_sites))
+        self.assertEqual(self.sensor.name(), sensor_sites[0].name)
+        assert_allclose(self.expected_pos, sensor_sites[0].pos)
+        assert_allclose(self.expected_euler, sensor_sites[0].euler)
+
+        mjcf_accel, mjcf_gyro = mjcf_sensors
+        self.assertAlmostEqual(f"accelerometer_{self.sensor.name()}",
+                               mjcf_accel.name)
+        self.assertAlmostEqual(self.sensor.name(), mjcf_accel.site)
+        self.assertAlmostEqual(accel_noise.std_dev(), mjcf_accel.noise)
+
+        self.assertAlmostEqual(f"gyro_{self.sensor.name()}",
+                               mjcf_gyro.name)
+        self.assertAlmostEqual(self.sensor.name(), mjcf_gyro.site)
+        self.assertAlmostEqual(gyro_noise.std_dev(), mjcf_gyro.noise)
+
+    def test_noise_mismatch(self):
+        imu = sdf.IMU()
+        accel_noise = sdf.Noise()
+        accel_noise.set_type(sdf.NoiseType.GAUSSIAN)
+        accel_noise.set_std_dev(0.2)
+
+        gyro_noise = sdf.Noise()
+        gyro_noise.set_type(sdf.NoiseType.GAUSSIAN)
+        gyro_noise.set_std_dev(0.02)
+
+        imu.set_linear_acceleration_x_noise(accel_noise)
+        imu.set_angular_velocity_x_noise(gyro_noise)
+
+        self.sensor.set_imu_sensor(imu)
+        with self.assertLogs(level="WARN") as cm:
+            mjcf_sensors = add_sensor(self.body, self.sensor)
+        self.assertEqual(2, len(cm.output))
+        self.assertIn("Noise parameter mismatch for linear_acceleration",
+                      cm.output[0])
+        self.assertIn("Noise parameter mismatch for angular_velocity",
+                      cm.output[1])
+
+        self.assertIsNotNone(mjcf_sensors)
+        self.assertEqual(2, len(mjcf_sensors))
+        mjcf_accel, mjcf_gyro = mjcf_sensors
+        self.assertIsNone(mjcf_accel.noise)
+        self.assertIsNone(mjcf_gyro.noise)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# 🎉 New feature

Toward #16

## Summary
The SDFormat IMU sensor is mapped to `sensor/accelerometer` and `sensor/gyro` in MJCF.

## Test it
`tests/test_add_sensor.py`
`tests/test_add_link.py`

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
