### PR TITLE
Fixed geom poses

### DIFF
--- a/mjcf_to_sdformat/mjcf_to_sdformat/converters/geometry.py
+++ b/mjcf_to_sdformat/mjcf_to_sdformat/converters/geometry.py
@@ -31,6 +31,13 @@ def mjcf_geom_to_sdf(geom):
     :return: The newly created SDFormat geometry.
     :rtype: sdf.Geometry
     """
+    if geom.root.default.geom is not None:
+        for k, v in geom.root.default.geom.get_attributes().items():
+            try:
+                geom.get_attributes()[k]
+            except KeyError:
+                geom.set_attributes(**{k: v})
+
     # TODO(ahcorde): we have to adjust the pose of the visual/collision to
     # match the longitudinal axis of the capsule/cylinder and its position
     # Related comment:

--- a/mjcf_to_sdformat/mjcf_to_sdformat/converters/geometry.py
+++ b/mjcf_to_sdformat/mjcf_to_sdformat/converters/geometry.py
@@ -31,12 +31,6 @@ def mjcf_geom_to_sdf(geom):
     :return: The newly created SDFormat geometry.
     :rtype: sdf.Geometry
     """
-    if geom.root.default.geom is not None:
-        for k, v in geom.root.default.geom.get_attributes().items():
-            try:
-                geom.get_attributes()[k]
-            except KeyError:
-                geom.set_attributes(**{k: v})
     # TODO(ahcorde): we have to adjust the pose of the visual/collision to
     # match the longitudinal axis of the capsule/cylinder and its position
     # Related comment:

--- a/mjcf_to_sdformat/mjcf_to_sdformat/converters/geometry.py
+++ b/mjcf_to_sdformat/mjcf_to_sdformat/converters/geometry.py
@@ -31,13 +31,6 @@ def mjcf_geom_to_sdf(geom):
     :return: The newly created SDFormat geometry.
     :rtype: sdf.Geometry
     """
-    if geom.root.default.geom is not None:
-        for k, v in geom.root.default.geom.get_attributes().items():
-            try:
-                geom.get_attributes()[k]
-            except KeyError:
-                geom.set_attributes(**{k: v})
-
     # TODO(ahcorde): we have to adjust the pose of the visual/collision to
     # match the longitudinal axis of the capsule/cylinder and its position
     # Related comment:

--- a/mjcf_to_sdformat/mjcf_to_sdformat/converters/geometry.py
+++ b/mjcf_to_sdformat/mjcf_to_sdformat/converters/geometry.py
@@ -31,6 +31,12 @@ def mjcf_geom_to_sdf(geom):
     :return: The newly created SDFormat geometry.
     :rtype: sdf.Geometry
     """
+    if geom.root.default.geom is not None:
+        for k, v in geom.root.default.geom.get_attributes().items():
+            try:
+                geom.get_attributes()[k]
+            except KeyError:
+                geom.set_attributes(**{k: v})
     # TODO(ahcorde): we have to adjust the pose of the visual/collision to
     # match the longitudinal axis of the capsule/cylinder and its position
     # Related comment:

--- a/mjcf_to_sdformat/mjcf_to_sdformat/converters/link.py
+++ b/mjcf_to_sdformat/mjcf_to_sdformat/converters/link.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ignition.math import Inertiald, MassMatrix3d, Vector3d, Pose3d, Quaterniond
+from ignition.math import (Inertiald, MassMatrix3d, Vector3d, Pose3d,
+                           Quaterniond)
 
 import math
 

--- a/mjcf_to_sdformat/mjcf_to_sdformat/converters/link.py
+++ b/mjcf_to_sdformat/mjcf_to_sdformat/converters/link.py
@@ -149,7 +149,6 @@ def mjcf_geom_to_sdf(body, body_parent_name=None):
             pose_form_to = Pose3d(get_position(geom), get_orientation(geom))
             pose = pose_form_to * su.get_pose_from_mjcf(geom)
             col.set_raw_pose(pose)
-            col.set_raw_pose(su.get_pose_from_mjcf(geom))
             link.add_collision(col)
 
     for geom in body.geom:

--- a/mjcf_to_sdformat/mjcf_to_sdformat/converters/link.py
+++ b/mjcf_to_sdformat/mjcf_to_sdformat/converters/link.py
@@ -115,6 +115,8 @@ def mjcf_geom_to_sdf(body, body_parent_name=None):
             quat = Quaterniond()
             quat.set_from_2_axes(z, vec)
             return quat
+        else:
+            return su.get_pose_from_mjcf(geom).rot()
         return Quaterniond()
 
     def get_position(geom):
@@ -129,15 +131,15 @@ def mjcf_geom_to_sdf(body, body_parent_name=None):
             v1 = Vector3d(geom.fromto[0], geom.fromto[1], geom.fromto[2])
             v2 = Vector3d(geom.fromto[3], geom.fromto[4], geom.fromto[5])
             return (v1 + v2) / 2.0
-        return Vector3d()
+        else:
+            return su.get_pose_from_mjcf(geom).pos()
 
     def set_visual(geom):
         visual = mjcf_visual_to_sdf(geom)
         if visual is not None:
             visual.set_name(su.prefix_name_with_index(
                 "visual", geom.name, NUMBER_OF_VISUAL))
-            pose_form_to = Pose3d(get_position(geom), get_orientation(geom))
-            pose = pose_form_to * su.get_pose_from_mjcf(geom)
+            pose = Pose3d(get_position(geom), get_orientation(geom))
             visual.set_raw_pose(pose)
             link.add_visual(visual)
 
@@ -146,8 +148,7 @@ def mjcf_geom_to_sdf(body, body_parent_name=None):
         if col is not None:
             col.set_name(su.prefix_name_with_index(
                 "collision", geom.name, NUMBER_OF_COLLISION))
-            pose_form_to = Pose3d(get_position(geom), get_orientation(geom))
-            pose = pose_form_to * su.get_pose_from_mjcf(geom)
+            pose = Pose3d(get_position(geom), get_orientation(geom))
             col.set_raw_pose(pose)
             link.add_collision(col)
 

--- a/mjcf_to_sdformat/mjcf_to_sdformat/converters/link.py
+++ b/mjcf_to_sdformat/mjcf_to_sdformat/converters/link.py
@@ -118,7 +118,6 @@ def mjcf_geom_to_sdf(body, body_parent_name=None):
             return quat
         else:
             return su.get_pose_from_mjcf(geom).rot()
-        return Quaterniond()
 
     def get_position(geom):
         """

--- a/mjcf_to_sdformat/mjcf_to_sdformat/converters/world.py
+++ b/mjcf_to_sdformat/mjcf_to_sdformat/converters/world.py
@@ -35,11 +35,11 @@ def mjcf_worldbody_to_sdf(mjcf_root, world):
 
     body = mjcf_root.worldbody.body
 
-    def iterate_bodies(input_body, model):
+    def iterate_bodies(input_body, model, body_parent_name=None):
         for body in input_body:
-            link = mjcf_geom_to_sdf(body)
+            link = mjcf_geom_to_sdf(body, body_parent_name=body_parent_name)
             model.add_link(link)
-            iterate_bodies(body.body, model)
+            iterate_bodies(body.body, model, body.name)
     iterate_bodies(body, model)
 
     world.add_model(model)

--- a/mjcf_to_sdformat/tests/resources/test_mujoco.xml
+++ b/mjcf_to_sdformat/tests/resources/test_mujoco.xml
@@ -13,6 +13,9 @@
          <inertial pos="1 2 3" euler="0 0 0" mass="2" diaginertia="0.026026 0.023326 0.011595"/>
          <geom type="box" name="col_body2" pos="0 0 0" group="3" size=".1 .2 .3" rgba="0 .9 0 1"/>
          <geom type="box" name="visual_body2" pos="0 0 0" group="0" size=".1 .2 .3" rgba="0 .9 0 1"/>
+         <body pos="0 0 1" name="body3">
+           <geom type="box" name="visual_body3" pos="0 0 0" size=".1 .2 .3" rgba="0 .9 0 1"/>
+         </body>
       </body>
    </worldbody>
 </mujoco>

--- a/mjcf_to_sdformat/tests/resources/test_mujoco.xml
+++ b/mjcf_to_sdformat/tests/resources/test_mujoco.xml
@@ -6,7 +6,7 @@
          <joint type="free"/>
          <inertial pos="0 1 0" mass="2" fullinertia="2 2 2 0 0 0"/>
          <geom type="box" pos="0.1 0.3 0.2" size=".1 .2 .3" rgba="0 .9 0 1"/>
-         <geom name="cylinder" type="capsule" mass="1" fromto="0 -0.06 0 0 0.06 0" size="0.05"/>
+         <geom name="cylinder" type="capsule" pos="1 2 3" mass="1" fromto="0 -0.06 0 0 0.06 0" size="0.05"/>
       </body>
       <body pos="0 1 0" name="body2">
          <joint type="free"/>

--- a/mjcf_to_sdformat/tests/resources/test_mujoco.xml
+++ b/mjcf_to_sdformat/tests/resources/test_mujoco.xml
@@ -6,6 +6,7 @@
          <joint type="free"/>
          <inertial pos="0 1 0" mass="2" fullinertia="2 2 2 0 0 0"/>
          <geom type="box" pos="0.1 0.3 0.2" size=".1 .2 .3" rgba="0 .9 0 1"/>
+         <geom name="cylinder" type="capsule" mass="1" fromto="0 -0.06 0 0 0.06 0" size="0.05"/>
       </body>
       <body pos="0 1 0" name="body2">
          <joint type="free"/>

--- a/mjcf_to_sdformat/tests/test_add_mjcf_worldbody_to_sdf.py
+++ b/mjcf_to_sdformat/tests/test_add_mjcf_worldbody_to_sdf.py
@@ -184,5 +184,6 @@ class ModelTest(unittest.TestCase):
         assert_allclose([0, 0, 0],
                         su.vec3d_to_list(collision_4.raw_pose().rot().euler()))
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/mjcf_to_sdformat/tests/test_add_mjcf_worldbody_to_sdf.py
+++ b/mjcf_to_sdformat/tests/test_add_mjcf_worldbody_to_sdf.py
@@ -64,8 +64,8 @@ class ModelTest(unittest.TestCase):
 
         link_2 = model.link_by_index(1)
         self.assertEqual("link_1", link_2.name())
-        self.assertEqual(1, link_2.visual_count())
-        self.assertEqual(1, link_2.collision_count())
+        self.assertEqual(2, link_2.visual_count())
+        self.assertEqual(2, link_2.collision_count())
         assert_allclose([0, 0, 1], su.vec3d_to_list(link_2.raw_pose().pos()))
         assert_allclose([0, 0, 0],
                         su.vec3d_to_list(link_2.raw_pose().rot().euler()))
@@ -95,6 +95,24 @@ class ModelTest(unittest.TestCase):
                         su.vec3d_to_list(collision_2.raw_pose().pos()))
         assert_allclose([0, 0, 0],
                         su.vec3d_to_list(collision_2.raw_pose().rot().euler()))
+
+        visual_2 = link_2.visual_by_index(1)
+        self.assertNotEqual(None, visual_2)
+        self.assertEqual("visual_cylinder", visual_2.name())
+        assert_allclose([0.0, 0.0, 0.0],
+                        su.vec3d_to_list(visual_2.raw_pose().pos()))
+        assert_allclose([1.570796, 0, 0],
+                        su.vec3d_to_list(visual_2.raw_pose().rot().euler()),
+                        rtol=1e-5)
+
+        collision_2 = link_2.collision_by_index(1)
+        self.assertNotEqual(None, collision_2)
+        self.assertEqual("collision_cylinder", collision_2.name())
+        assert_allclose([0.0, 0.0, 0.0],
+                        su.vec3d_to_list(collision_2.raw_pose().pos()))
+        assert_allclose([1.570796, 0, 0],
+                        su.vec3d_to_list(collision_2.raw_pose().rot().euler()),
+                        rtol=1e-5)
 
         link_3 = model.link_by_index(2)
         self.assertEqual("body2", link_3.name())

--- a/mjcf_to_sdformat/tests/test_add_mjcf_worldbody_to_sdf.py
+++ b/mjcf_to_sdformat/tests/test_add_mjcf_worldbody_to_sdf.py
@@ -174,6 +174,7 @@ class ModelTest(unittest.TestCase):
         self.assertEqual("body3", link_4.name())
         self.assertEqual(1, link_4.visual_count())
         self.assertEqual(1, link_4.collision_count())
+        self.assertEqual("body2", link_4.pose_relative_to())
 
         mass_matrix = link_4.inertial().mass_matrix()
         self.assertEqual(1, mass_matrix.mass())

--- a/mjcf_to_sdformat/tests/test_add_mjcf_worldbody_to_sdf.py
+++ b/mjcf_to_sdformat/tests/test_add_mjcf_worldbody_to_sdf.py
@@ -39,7 +39,7 @@ class ModelTest(unittest.TestCase):
         self.assertEqual(1, world.model_count())
         model = world.model_by_index(0)
         self.assertNotEqual(None, model)
-        self.assertEqual(3, model.link_count())
+        self.assertEqual(4, model.link_count())
         link_1 = model.link_by_index(0)
         self.assertEqual("link_0", link_1.name())
         self.assertEqual(1, link_1.visual_count())
@@ -149,6 +149,40 @@ class ModelTest(unittest.TestCase):
         assert_allclose([0, 0, 0],
                         su.vec3d_to_list(collision_3.raw_pose().rot().euler()))
 
+        link_4 = model.link_by_index(3)
+        self.assertEqual("body3", link_4.name())
+        self.assertEqual(1, link_4.visual_count())
+        self.assertEqual(1, link_4.collision_count())
+
+        mass_matrix = link_4.inertial().mass_matrix()
+        self.assertEqual(1, mass_matrix.mass())
+        self.assertEqual([0, 0, 0],
+                         su.vec3d_to_list(link_4.inertial().pose().pos()))
+        self.assertEqual([0, 0, 0],
+                         su.vec3d_to_list(link_4.inertial().pose().rot()))
+        assert_allclose([1, 1, 1],
+                        su.vec3d_to_list(mass_matrix.diagonal_moments()))
+        assert_allclose([0, 0, 0],
+                        su.vec3d_to_list(mass_matrix.off_diagonal_moments()))
+
+        assert_allclose([0, 0, 1], su.vec3d_to_list(link_4.raw_pose().pos()))
+        assert_allclose([0, 0, 0],
+                        su.vec3d_to_list(link_4.raw_pose().rot().euler()))
+        visual_4 = link_4.visual_by_index(0)
+        self.assertNotEqual(None, visual_4)
+        self.assertEqual("visual_visual_body3", visual_4.name())
+        assert_allclose([0.0, 0, 0],
+                        su.vec3d_to_list(visual_4.raw_pose().pos()))
+        assert_allclose([0, 0, 0],
+                        su.vec3d_to_list(visual_4.raw_pose().rot().euler()))
+
+        collision_4 = link_4.collision_by_index(0)
+        self.assertNotEqual(None, collision_4)
+        self.assertEqual("collision_visual_body3", collision_4.name())
+        assert_allclose([0, 0, 0],
+                        su.vec3d_to_list(collision_4.raw_pose().pos()))
+        assert_allclose([0, 0, 0],
+                        su.vec3d_to_list(collision_4.raw_pose().rot().euler()))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

This PR fixes the pose of the visuals/collisions

 - subbodies are "relative_to" the parent body
 - fromto set the orientation and pose of the geom

![Selection_077](https://user-images.githubusercontent.com/1933907/170346323-6f0c9e6a-6a01-4af9-bf49-c6b487723414.png)

You can test this with the `acrobot.xml` file inside `dm_control`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
