### PR TITLE
SDFormat to MJCF: Add support for force/torque sensors

### DIFF
--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/joint.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/joint.py
@@ -18,6 +18,7 @@ import math
 
 import sdformat as sdf
 
+from sdformat_to_mjcf.converters.sensor import add_sensor
 import sdformat_mjcf_utils.sdf_utils as su
 
 JOINT_DEFAULT_UPPER_LIMIT = 1e16
@@ -64,14 +65,42 @@ def add_joint(body, joint):
     """
     if joint is None:
         return body.add("freejoint")
-    elif joint.type() == sdf.JointType.FIXED:
+
+    pose = su.graph_resolver.resolve_pose(joint.semantic_pose())
+
+    for si in range(joint.sensor_count()):
+        sensor = joint.sensor_by_index(si)
+        if sensor is not None:
+            mjcf_sensors = add_sensor(body, sensor)
+            if mjcf_sensors and sensor.force_torque_sensor() is not None:
+                ft_sensor = sensor.force_torque_sensor()
+                # The SDFormat spec says:
+                # "Note that for each option the point with respect to which
+                # the torque component of the wrench is expressed is the joint
+                # origin." Therefore, we set the site's position to the
+                # position of the joint.
+                site = body.find('site', mjcf_sensors[0].site)
+                site.pos = su.vec3d_to_list(pose.pos())
+
+                # The orientation of the site depends on the <frame> element.
+                # PARENT and CHILD frames imply using the rotation of the
+                # parent and child bodies respectively. SENSOR implies using
+                # the rotation of the sensor frame, but since this is set in
+                # `add_sensor`, we do nothing here.
+                if (ft_sensor.frame() == sdf.ForceTorqueFrame.PARENT
+                        and body.parent.euler is not None):  # noqa
+                    site.euler = body.parent.euler
+                elif (ft_sensor.frame() == sdf.ForceTorqueFrame.CHILD
+                      and body.euler is not None):  # noqa
+                    site.euler = body.euler
+
+    if joint.type() == sdf.JointType.FIXED:
         return None
     elif joint.type() in [
             sdf.JointType.CONTINUOUS,
             sdf.JointType.REVOLUTE,
             sdf.JointType.PRISMATIC
     ]:
-        pose = su.graph_resolver.resolve_pose(joint.semantic_pose())
         unique_name = su.find_unique_name(body, "joint", joint.name())
         mjcf_joint = body.add("joint", name=unique_name)
         mjcf_joint.pos = su.vec3d_to_list(pose.pos())

--- a/sdformat_to_mjcf/sdformat_to_mjcf/sformat_to_mjcf.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/sformat_to_mjcf.py
@@ -34,6 +34,7 @@ def sdformat_file_to_mjcf(input_file, output_file):
         return 1
     else:
         mjcf_root = add_root(root)
-        export_with_assets(mjcf_root, os.path.dirname(output_file),
+        export_with_assets(mjcf_root,
+                           os.path.dirname(os.path.abspath(output_file)),
                            output_file)
         return 0


### PR DESCRIPTION
# 🎉 New feature

Toward  #16 
## Summary
The handling of `//force_torque/frame` is a little tricky. My interpretation of the SDFormat spec is that the reported torque is always about the joint origin, so I'm setting the `pos` of the mjcf site for the sensor to the joint origin regardless of the value in `//force_torque/frame`. For the rotation, I'm setting the rotation of the mjcf site for the sensor to the rotation of the body indicated by `//force_torque/frame`. 

## Test it
`test_add_sensor.py`
`test_add_joint.py`

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
