### PR TITLE
MJCF to SDF: Set wordlbody geom as static model

### DIFF
--- a/mjcf_to_sdformat/mjcf_to_sdformat/converters/world.py
+++ b/mjcf_to_sdformat/mjcf_to_sdformat/converters/world.py
@@ -14,6 +14,8 @@
 
 from mjcf_to_sdformat.converters.link import mjcf_geom_to_sdf
 
+import sdformat_mjcf_utils.sdf_utils as su
+
 import sdformat as sdf
 
 
@@ -30,8 +32,13 @@ def mjcf_worldbody_to_sdf(mjcf_root, world):
     else:
         model.set_name("model")
 
+    model_static = sdf.Model()
     link = mjcf_geom_to_sdf(mjcf_root.worldbody)
-    model.add_link(link)
+    model_static.set_name(su.find_unique_name(
+        mjcf_root.worldbody, "geom", "static"))
+    model_static.add_link(link)
+    model_static.set_static(True)
+    world.add_model(model_static)
 
     body = mjcf_root.worldbody.body
 

--- a/mjcf_to_sdformat/tests/test_add_mjcf_worldbody_to_sdf.py
+++ b/mjcf_to_sdformat/tests/test_add_mjcf_worldbody_to_sdf.py
@@ -36,10 +36,10 @@ class ModelTest(unittest.TestCase):
         mjcf_worldbody_to_sdf(mjcf_model, world)
 
         self.assertEqual("default", world.name())
-        self.assertEqual(1, world.model_count())
+        self.assertEqual(2, world.model_count())
         model = world.model_by_index(0)
         self.assertNotEqual(None, model)
-        self.assertEqual(3, model.link_count())
+        self.assertEqual(1, model.link_count())
         link_1 = model.link_by_index(0)
         self.assertEqual("link_0", link_1.name())
         self.assertEqual(1, link_1.visual_count())
@@ -62,7 +62,9 @@ class ModelTest(unittest.TestCase):
         assert_allclose([0, 0, 0],
                         su.vec3d_to_list(collision_1.raw_pose().rot().euler()))
 
-        link_2 = model.link_by_index(1)
+        model = world.model_by_index(1)
+        self.assertNotEqual(None, model)
+        link_2 = model.link_by_index(0)
         self.assertEqual("link_1", link_2.name())
         self.assertEqual(1, link_2.visual_count())
         self.assertEqual(1, link_2.collision_count())
@@ -96,7 +98,7 @@ class ModelTest(unittest.TestCase):
         assert_allclose([0, 0, 0],
                         su.vec3d_to_list(collision_2.raw_pose().rot().euler()))
 
-        link_3 = model.link_by_index(2)
+        link_3 = model.link_by_index(1)
         self.assertEqual("body2", link_3.name())
         self.assertEqual(1, link_3.visual_count())
         self.assertEqual(1, link_3.collision_count())

--- a/mjcf_to_sdformat/tests/test_add_mjcf_worldbody_to_sdf.py
+++ b/mjcf_to_sdformat/tests/test_add_mjcf_worldbody_to_sdf.py
@@ -40,6 +40,7 @@ class ModelTest(unittest.TestCase):
         model = world.model_by_index(0)
         self.assertNotEqual(None, model)
         self.assertEqual(1, model.link_count())
+        self.assertTrue(model.static())
         link_1 = model.link_by_index(0)
         self.assertEqual("link_0", link_1.name())
         self.assertEqual(1, link_1.visual_count())


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>
# 🦟 Bug fix

## Summary

MJCF to SDF: Set wordlbody geom as static model

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
