### PR TITLE
Fix link pose so that it reflects the parent model's pose

### DIFF
--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/link.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/link.py
@@ -19,7 +19,7 @@ from sdformat_to_mjcf.converters.sensor import add_sensor
 import sdformat_mjcf_utils.sdf_utils as su
 
 
-def add_link(body, link, parent_name="world"):
+def add_link(body, link, parent_name="world", link_pose=None):
     """
     Converts a link from SDFormat to MJCF and add it to the given
     body/worldbody.
@@ -27,8 +27,8 @@ def add_link(body, link, parent_name="world"):
     :param mjcf.Element body: The MJCF body to which the body is added.
     :param sdformat.Link link: The SDFormat link to be converted.
     :param str parent_name: Name of parent link.
-    :param str mode_name: Name of the model who contains the link. This is used
-    to generate the name and avoid collisions in the names
+    :param ignition.math.Pose3d link_pose: Pose of link. This is optional and
+    if set to None, the pose will be resolved from the link.
     :return: The newly created MJCF body.
     :rtype: mjcf.Element
     """
@@ -43,11 +43,14 @@ def add_link(body, link, parent_name="world"):
     #     - audio_source
     #     - battery
     #     - particle_emitter
-    sem_pose = link.semantic_pose()
-    if parent_name == 'world':
-        pose = su.graph_resolver.resolve_pose(sem_pose)
+    if link_pose is not None:
+        pose = link_pose
     else:
-        pose = su.graph_resolver.resolve_pose(sem_pose, parent_name)
+        sem_pose = link.semantic_pose()
+        if parent_name == 'world':
+            pose = su.graph_resolver.resolve_pose(sem_pose)
+        else:
+            pose = su.graph_resolver.resolve_pose(sem_pose, parent_name)
 
     body = body.add("body",
                     name=su.find_unique_name(body, "body", link.name()),

--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/model.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/model.py
@@ -36,10 +36,9 @@ def add_model(mjcf_root, model):
     kin_hierarchy = KinematicHierarchy(model)
     model_pose = graph_resolver.resolve_pose(model.semantic_pose())
 
-    def convert_node(body, node):
-        child_body = add_link(body,
-                              node.link,
-                              node.parent_node.link.name())
+    def convert_node(body, node, link_pose=None):
+        child_body = add_link(body, node.link, node.parent_node.link.name(),
+                              link_pose)
 
         add_joint(child_body, node.joint)
         # Geoms added to bodies attached to the worldbody without a
@@ -74,8 +73,6 @@ def add_model(mjcf_root, model):
         # Adjust the poses of each of the nodes to account for the model
         link_pose = graph_resolver.resolve_pose(cn.link.semantic_pose())
         new_link_pose = model_pose * link_pose
-        cn.link.set_raw_pose(new_link_pose)
-        cn.link.set_pose_relative_to("")
-        convert_node(mjcf_root.worldbody, cn)
+        convert_node(mjcf_root.worldbody, cn, new_link_pose)
 
     return mjcf_root


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
The Model pose was not being reflected on the generated MJCF body's pose. The previous approach was working fine in tests because we bypass pose resolution. An integration test where a full SDFormat file is loaded shows the error.

The issue with the previous approach was the setting `link.set_raw_pose` does not affect the pose graphs in SDFormat, so consequent pose resolution queries do not contain the new pose set via `link.set_raw_pose`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
