### PR TITLE
SDFormat to MJCF: Handle static models

### DIFF
--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/joint.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/joint.py
@@ -17,8 +17,10 @@
 import math
 
 import sdformat as sdf
+from ignition.math import Pose3d
 
 from sdformat_to_mjcf.converters.sensor import add_sensor
+from sdformat_to_mjcf.sdf_kinematics import FreeJoint, StaticFixedJoint
 import sdformat_mjcf_utils.sdf_utils as su
 
 JOINT_DEFAULT_UPPER_LIMIT = 1e16
@@ -63,10 +65,13 @@ def add_joint(body, joint):
     :return: The newly created MJCF joint.
     :rtype: mjcf.Element
     """
-    if joint is None:
+    if isinstance(joint, FreeJoint):
         return body.add("freejoint")
 
-    pose = su.graph_resolver.resolve_pose(joint.semantic_pose())
+    if isinstance(joint, StaticFixedJoint):
+        pose = Pose3d()
+    else:
+        pose = su.graph_resolver.resolve_pose(joint.semantic_pose())
 
     for si in range(joint.sensor_count()):
         sensor = joint.sensor_by_index(si)

--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/joint.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/joint.py
@@ -69,6 +69,9 @@ def add_joint(body, joint):
         return body.add("freejoint")
 
     if isinstance(joint, StaticFixedJoint):
+        # The pose of this joint can be chosen arbitrarily since the purpose
+        # of the joint is to anchor static objects to the world. Any choice of
+        # poses will have the same effect, so we choose the identity pose here.
         pose = Pose3d()
     else:
         pose = su.graph_resolver.resolve_pose(joint.semantic_pose())

--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/model.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/model.py
@@ -14,7 +14,7 @@
 
 from dm_control import mjcf
 
-from sdformat_to_mjcf.sdf_kinematics import KinematicHierarchy
+from sdformat_to_mjcf.sdf_kinematics import KinematicHierarchy, FreeJoint
 from sdformat_to_mjcf.converters.link import add_link
 from sdformat_to_mjcf.converters.joint import add_joint
 from sdformat_mjcf_utils.sdf_utils import graph_resolver
@@ -52,7 +52,7 @@ def add_model(mjcf_root, model):
         # will collide with eachother since the geoms of A are considered
         # to belong to worldbody. To avoid this problem, we create contact
         # exclusions between A and B.
-        if node.joint is None:
+        if isinstance(node.joint, FreeJoint):
             should_add_exclusions = False
         else:
             is_fixed_joint = node.joint.type() == sdf.JointType.FIXED

--- a/sdformat_to_mjcf/sdformat_to_mjcf/sdf_kinematics.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/sdf_kinematics.py
@@ -16,11 +16,25 @@ import sdformat as sdf
 import sdformat_mjcf_utils.sdf_utils as su
 
 
+class StaticFixedJoint(sdf.Joint):
+    """Joint that represents fixed joints created for connect links in static
+    models to the worldbody."""
+    def __init__(self):
+        super().__init__()
+        self.set_type(sdf.JointType.FIXED)
+
+
+class FreeJoint(sdf.Joint):
+    """Joint that represents free joints that are not explicitly in the
+    SDFormat file, but are needed in MJCF."""
+    pass
+
+
 class LinkNode:
     """
     A Node that represents links/bodies in KinematicHierarchy defined below.
     """
-    def __init__(self, link, parent=None, joint=None):
+    def __init__(self, link, parent=None, joint=FreeJoint()):
         """
         Initialize the node with an SDFormat link, an optional parent node and
         an optional joint
@@ -83,11 +97,7 @@ class KinematicHierarchy:
         for li in range(model.link_count()):
             node = LinkNode(model.link_by_index(li), self.world_node)
             link_to_node_dict[node.link] = node
-            if model.static():
-                joint = sdf.Joint()
-                joint.set_type(sdf.JointType.FIXED)
-            else:
-                joint = None
+            joint = StaticFixedJoint() if model.static() else FreeJoint()
             self.world_node.add_child(node, joint)
 
         for ji in range(model.joint_count()):

--- a/sdformat_to_mjcf/sdformat_to_mjcf/sdf_kinematics.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/sdf_kinematics.py
@@ -17,7 +17,7 @@ import sdformat_mjcf_utils.sdf_utils as su
 
 
 class StaticFixedJoint(sdf.Joint):
-    """Joint that represents fixed joints created for connect links in static
+    """Joint that represents fixed joints created to connect links in static
     models to the worldbody."""
     def __init__(self):
         super().__init__()

--- a/sdformat_to_mjcf/sdformat_to_mjcf/sdf_kinematics.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/sdf_kinematics.py
@@ -83,7 +83,12 @@ class KinematicHierarchy:
         for li in range(model.link_count()):
             node = LinkNode(model.link_by_index(li), self.world_node)
             link_to_node_dict[node.link] = node
-            self.world_node.add_child(node, None)
+            if model.static():
+                joint = sdf.Joint()
+                joint.set_type(sdf.JointType.FIXED)
+            else:
+                joint = None
+            self.world_node.add_child(node, joint)
 
         for ji in range(model.joint_count()):
             joint = model.joint_by_index(ji)

--- a/sdformat_to_mjcf/tests/test_add_joint.py
+++ b/sdformat_to_mjcf/tests/test_add_joint.py
@@ -22,6 +22,7 @@ from ignition.math import Pose3d, Vector3d
 from dm_control import mjcf
 
 from sdformat_to_mjcf.converters.joint import add_joint
+from sdformat_to_mjcf.sdf_kinematics import FreeJoint, StaticFixedJoint
 import sdformat_mjcf_utils.sdf_utils as su
 from tests import helpers
 
@@ -63,22 +64,26 @@ class JointTest(helpers.TestCase):
         return joint
 
     def test_free_joint(self):
-        mj_joint = add_joint(self.body, None)
+        mj_joint = add_joint(self.body, FreeJoint())
         self.assertIsNotNone(mj_joint)
         self.assertEqual("freejoint", mj_joint.tag)
 
     def test_multiple_free_joints(self):
-        mj_joint1 = add_joint(self.body, None)
+        mj_joint1 = add_joint(self.body, FreeJoint())
         self.assertIsNotNone(mj_joint1)
         # Add another body with a free joint to worldbody
         body2 = self.mujoco.worldbody.add("body", name="test_body")
-        mj_joint2 = add_joint(body2, None)
+        mj_joint2 = add_joint(body2, FreeJoint())
         self.assertIsNotNone(mj_joint2)
 
     def test_fixed_joint(self):
         joint = sdf.Joint()
         joint.set_type(sdf.JointType.FIXED)
         mj_joint = add_joint(self.body, joint)
+        self.assertIsNone(mj_joint)
+
+    def test_static_fixed_joint(self):
+        mj_joint = add_joint(self.body, StaticFixedJoint())
         self.assertIsNone(mj_joint)
 
     def test_revolute_joint(self):

--- a/sdformat_to_mjcf/tests/test_add_model.py
+++ b/sdformat_to_mjcf/tests/test_add_model.py
@@ -21,6 +21,7 @@ from ignition.math import Pose3d
 from dm_control import mjcf
 
 from sdformat_to_mjcf.converters.model import add_model
+from sdformat_to_mjcf.converters.root import add_root
 import sdformat_mjcf_utils.sdf_utils as su
 from tests import helpers
 
@@ -168,6 +169,8 @@ class ModelTest(helpers.TestCase):
         self.assertEqual("link1", excludes[0].body1)
         self.assertEqual("link2", excludes[0].body2)
 
+
+class ModelIntegrationTest(unittest.TestCase):
     def test_static_model(self):
         test_model_sdf = """
         <sdf version="1.6">
@@ -186,7 +189,7 @@ class ModelTest(helpers.TestCase):
         root = sdf.Root()
         errors = root.load_sdf_string(test_model_sdf)
         self.assertEqual(0, len(errors))
-        mj_root = add_model(self.mujoco, root.model())
+        mj_root = add_root(root)
         self.assertIsNotNone(mj_root)
         mj_link1 = mj_root.find("body", "link1")
         self.assertFalse(mj_link1.get_children("joint"))

--- a/sdformat_to_mjcf/tests/test_add_model.py
+++ b/sdformat_to_mjcf/tests/test_add_model.py
@@ -168,6 +168,30 @@ class ModelTest(helpers.TestCase):
         self.assertEqual("link1", excludes[0].body1)
         self.assertEqual("link2", excludes[0].body2)
 
+    def test_static_model(self):
+        test_model_sdf = """
+        <sdf version="1.6">
+            <model name="test_model">
+                <static>true</static>
+                <link name="link1">
+                    <collision name="c1">
+                        <geometry>
+                            <sphere><radius>2</radius></sphere>
+                        </geometry>
+                    </collision>
+                </link>
+            </model>
+        </sdf>
+        """
+        root = sdf.Root()
+        errors = root.load_sdf_string(test_model_sdf)
+        self.assertEqual(0, len(errors))
+        mj_root = add_model(self.mujoco, root.model())
+        self.assertIsNotNone(mj_root)
+        mj_link1 = mj_root.find("body", "link1")
+        self.assertFalse(mj_link1.get_children("joint"))
+        self.assertFalse(mj_link1.get_children("freejoint"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# 🎉 New feature

## Summary
Bodies converted from Links in static models are connected to the `worldbody` by a static joint.

This also introduces two new classes `FreeJoint` and `StaticFixedJoint` which can be used to designate joints that don't actually exist in the SDFormat file but are created by the converter to facilitate conversion to MJCF.

## Test it
`test_add_model.py`

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.