### PR TITLE
SDFormat to MJCF: Fix bug with plane sizes

### DIFF
--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/geometry.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/geometry.py
@@ -66,7 +66,7 @@ def add_geometry(body, name, pose, sdf_geom):
         # The third element of size defines the spacing between square grid
         # lines for rendering.
         # TODO (azeey) Consider making this configurable
-        geom.size = su.vec2d_to_list(plane_shape.size() / 2.0) + [0]
+        geom.size = su.vec2d_to_list(plane_shape.size() / 2.0) + [1]
     elif sdf_geom.sphere_shape():
         sphere_shape = sdf_geom.sphere_shape()
         geom.type = "sphere"

--- a/sdformat_to_mjcf/tests/test_add_geometry.py
+++ b/sdformat_to_mjcf/tests/test_add_geometry.py
@@ -24,6 +24,7 @@ from dm_control import mjcf
 
 from tests import helpers
 from sdformat_to_mjcf.converters import geometry as geometry_conv
+from sdformat_to_mjcf.converters.root import add_root
 
 
 class GeometryTest(helpers.TestCase):
@@ -154,7 +155,7 @@ class GeometryTest(helpers.TestCase):
                                              self.test_pose, geometry)
         self.assertEqual("plane_shape", mj_geom.name)
         self.assertEqual("plane", mj_geom.type)
-        assert_allclose([x_size / 2., y_size / 2., 0.], mj_geom.size)
+        assert_allclose([x_size / 2., y_size / 2., 1.], mj_geom.size)
         assert_allclose(self.expected_pos, mj_geom.pos)
         assert_allclose(self.expected_euler, mj_geom.euler)
 
@@ -218,6 +219,34 @@ class VisualTest(helpers.TestCase):
         assert_allclose([1., 2., 3.], mj_geom.pos)
         assert_allclose([90., 60., 45.], mj_geom.euler)
         self.assertEqual(geometry_conv.VISUAL_GEOM_GROUP, mj_geom.group)
+
+
+class GeometryIntegrationTest(unittest.TestCase):
+
+    def test_plane_size(self):
+        test_model_sdf = """
+        <sdf version="1.6">
+            <world name="default">
+                <model name="test_model">
+                    <static>true</static>
+                    <link name="link1">
+                        <visual name="c1">
+                            <geometry>
+                                <plane><size>10 10</size></plane>
+                            </geometry>
+                        </visual>
+                    </link>
+                </model>
+            </world>
+        </sdf>
+        """
+
+        root = sdf.Root()
+        root.load_sdf_string(test_model_sdf)
+        mj_root = add_root(root)
+        self.assertIsNotNone(mj_root)
+        physics = mjcf.Physics.from_mjcf_model(mj_root)
+        self.assertIsNotNone(physics)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This was brought up by @scpeters  in https://github.com/gazebosim/gz-mujoco/pull/2/files/d0eaa013fd4a68b5fe5c172f3042278808f0a9f1#r866318057 and I responded saying setting it 0 causes Mujoco to fail, but somehow I merged the PR without fixing it. 

This sets the third component of a plane's size to 1. I don't have a good reason for setting it that, but it fixes the failure for now. This could be configurable via command line flag.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
