### PR TITLE
mjcf -> SDFormat: minor fixes

### DIFF
--- a/mjcf_to_sdformat/README.md
+++ b/mjcf_to_sdformat/README.md
@@ -34,7 +34,7 @@ pip install -e path/to/mjcf_to_sdformat
 To convert an SDFormat file to mjcf:
 
 ```
-python -m mjcf_to_sdformat.mjcf2sdformat path/to/file.xml | tee new_file.sdf
+mjcf2sdformat path/to/file.xml new_file.sdf
 ```
 
 To run the sdf file in GazeboSim, follow [this instructions to install Gazebo Sim](https://gazebosim.org/docs/latest/install)

--- a/mjcf_to_sdformat/mjcf_to_sdformat/converters/geometry.py
+++ b/mjcf_to_sdformat/mjcf_to_sdformat/converters/geometry.py
@@ -102,7 +102,7 @@ def mjcf_visual_to_sdf(geom):
         visual.set_name("visual_" + geom.name)
     else:
         global VISUAL_NUMBER
-        visual.set_name("visual_" + str(VISUAL_NUMBER))
+        visual.set_name("unnamed_visual_" + str(VISUAL_NUMBER))
         VISUAL_NUMBER = VISUAL_NUMBER + 1
     sdf_geometry = mjcf_geom_to_sdf(geom)
     if sdf_geometry is not None:
@@ -126,7 +126,7 @@ def mjcf_collision_to_sdf(geom):
         col.set_name("collision_" + geom.name)
     else:
         global COLLISION_NUMBER
-        col.set_name("collision_" + str(COLLISION_NUMBER))
+        col.set_name("unnamed_collision_" + str(COLLISION_NUMBER))
         COLLISION_NUMBER = COLLISION_NUMBER + 1
     sdf_geometry = mjcf_geom_to_sdf(geom)
     if sdf_geometry is not None:


### PR DESCRIPTION
# 🦟 Bug fix

Two minor fixes for things I noticed during code review

## Summary

* https://github.com/gazebosim/gz-mujoco/commit/cf34f52e6ac43811102d6f73041816bed84b1371: fix syntax for example `mjcf2sdformat` command in `README`
* https://github.com/gazebosim/gz-mujoco/commit/f1fdecedfa3a3bd8605fbc45c1938356371354e0: add `unnamed_` prefix to collisions and visuals without a name to match the behavior for unnamed joints.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
