### PR TITLE
SDFormat to MJCF: Add conversion for camera sensor

### DIFF
--- a/sdformat_to_mjcf/tests/test_add_link.py
+++ b/sdformat_to_mjcf/tests/test_add_link.py
@@ -187,6 +187,20 @@ class LinkTest(helpers.TestCase):
         mjcf_gyros = self.mujoco.sensor.get_children("gyro")
         self.assertEqual(1, len(mjcf_gyros))
 
+    def test_camera_sensor(self):
+        link = sdf.Link()
+        link.set_name("base_link")
+        sensor = sdf.Sensor()
+        sensor.set_name("camera_sensor")
+        sensor.set_type(sdf.Sensortype.CAMERA)
+        sensor.set_raw_pose(self.test_pose)
+        camera = sdf.Camera()
+        sensor.set_camera_sensor(camera)
+        link.add_sensor(sensor)
+        mj_body = add_link(self.body, link)
+        self.assertIsNotNone(mj_body)
+        self.assertEqual(1, len(mj_body.get_children("camera")))
+
 
 class LinkIntegration(unittest.TestCase):
     expected_pos = [1.0, 2.0, 3.0]

--- a/sdformat_to_mjcf/tests/test_add_sensor.py
+++ b/sdformat_to_mjcf/tests/test_add_sensor.py
@@ -243,5 +243,30 @@ class ForceTorqueSensorTest(helpers.TestCase):
                 " of Force/Torque sensor", cm.output[0])
 
 
+class CameraTest(helpers.TestCase):
+    test_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)
+    expected_pos = [1.0, 2.0, 3.0]
+    expected_euler = [90.0, 60.0, 45.0]
+
+    def setUp(self):
+        self.mujoco = mjcf.RootElement(model="test")
+        self.body = self.mujoco.worldbody.add("body", name="test_body")
+        self.sensor = sdf.Sensor()
+        self.sensor.set_name("camera_sensor")
+        self.sensor.set_type(sdf.Sensortype.CAMERA)
+        self.sensor.set_raw_pose(self.test_pose)
+
+    def test_default(self):
+        camera_sensor = sdf.Camera()
+        self.sensor.set_camera_sensor(camera_sensor)
+        mjcf_sensor = add_sensor(self.body, self.sensor)
+
+        self.assertIsNotNone(mjcf_sensor)
+        mj_cameras = self.body.get_children("camera")
+        self.assertEqual(1, len(mj_cameras))
+        assert_allclose(self.expected_pos, mjcf_sensor.pos)
+        assert_allclose(self.expected_euler, mjcf_sensor.euler)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# 🎉 New feature

Toward #16 

## Summary

It turns out there is not much to convert for cameras since Mujoco cameras are really not sensors. I added a warning just to let the user know that almost none of the sensor parameters are mapped.

## Test it
`test_add_sensor.py`
`test_add_link.py`

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
