### PR TITLE
Suggestions for default valued materials

### DIFF
--- a/mjcf_to_sdformat/tests/resources/test_mujoco.xml
+++ b/mjcf_to_sdformat/tests/resources/test_mujoco.xml
@@ -2,6 +2,7 @@
    <asset>
      <material name="material_1" emission="0.0" specular="0.3"
               rgba="0.36 0.36 0.36 1"/>
+     <material name="material_defaults"/>
    </asset>
    <default>
      <geom type="capsule" mass="1"/>
@@ -23,6 +24,7 @@
          <geom type="box" pos="0.1 0.3 0.2" size=".1 .2 .3" material="material_1"/>
          <geom name="who_is_this" fromto="0 0 0 0 0 1" size="0.05"/>
          <geom name="capsule" type="capsule" mass="1" fromto="0 -0.06 0 0 0.06 0" size="0.05"/>
+         <geom name="default_mat" size="1 1" material="material_defaults"/>
       </body>
       <body pos="0 1 0" name="body2" quat="0.5 0 0.5 0">
          <freejoint name="freejoint2"/>

--- a/mjcf_to_sdformat/tests/test_add_mjcf_worldbody_to_sdf.py
+++ b/mjcf_to_sdformat/tests/test_add_mjcf_worldbody_to_sdf.py
@@ -95,8 +95,8 @@ class ModelTest(unittest.TestCase):
         self.assertNotEqual(None, model)
         link_2 = model.link_by_index(0)
         self.assertEqual("link_1", link_2.name())
-        self.assertEqual(3, link_2.visual_count())
-        self.assertEqual(3, link_2.collision_count())
+        self.assertEqual(4, link_2.visual_count())
+        self.assertEqual(4, link_2.collision_count())
         assert_allclose([0, 0, 1], su.vec3d_to_list(link_2.raw_pose().pos()))
         assert_allclose([0, 0, 0],
                         su.vec3d_to_list(link_2.raw_pose().rot().euler()))

--- a/mjcf_to_sdformat/tests/test_mjcf_material_to_sdf.py
+++ b/mjcf_to_sdformat/tests/test_mjcf_material_to_sdf.py
@@ -49,6 +49,14 @@ class MaterialTest(unittest.TestCase):
         self.assertEqual(Color(0, 0.9, 0, 1.0), material.ambient())
         self.assertEqual(Color(0, 0.9, 0, 1.0), material.specular())
         self.assertEqual(Color(0, 0.9, 0, 1.0), material.emissive())
+        geom_default_mat = mjcf_model.find("geom", "default_mat")
+        self.assertIsNotNone(geom_default_mat)
+        material = mjcf_material_to_sdf(geom_default_mat)
+        self.assertNotEqual(None, material)
+        self.assertEqual(Color(1, 1, 1, 1.0), material.diffuse())
+        self.assertEqual(Color(1, 1, 1, 1.0), material.ambient())
+        self.assertEqual(Color(0.5, 0.5, 0.5, 1.0), material.specular())
+        self.assertEqual(Color(0, 0, 0, 1.0), material.emissive())
 
     def test_material_texture(self):
         mjcf_model = mjcf.from_path(
@@ -79,8 +87,8 @@ class MaterialTest(unittest.TestCase):
         material = visual.material()
         self.assertNotEqual(None, material)
         self.assertEqual(Color(1, 1, 1, 1.0), material.diffuse())
-        self.assertEqual(Color(0, 0, 0, 1.0), material.ambient())
-        self.assertEqual(Color(1, 1, 1, 1.0), material.specular())
+        self.assertEqual(Color(1, 1, 1, 1.0), material.ambient())
+        self.assertEqual(Color(0.5, 0.5, 0.5, 1.0), material.specular())
         self.assertEqual(Color(0, 0, 0, 1.0), material.emissive())
         pbr = material.pbr_material()
         self.assertNotEqual(None, pbr)


### PR DESCRIPTION
## Summary
The default value of a materials rgba is [1 1 1 1], so I thought we should use that when `material.rgba` is `None`. This also increases test coverage by testing default values of emission and specular. The documentation on `material.rgba` also states
> Note that textures are applied in GL_MODULATE mode, meaning that the texture color and the color specified here are multiplied component-wise. 
So, we should not discard the rgba values when setting textures.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
