### PR TITLE
MJCF->SDFormat: Fix sizes for infinite planes

### DIFF
--- a/mjcf_to_sdformat/mjcf_to_sdformat/converters/geometry.py
+++ b/mjcf_to_sdformat/mjcf_to_sdformat/converters/geometry.py
@@ -22,6 +22,9 @@ import sdformat_mjcf_utils.sdf_utils as su
 VISUAL_NUMBER = 0
 COLLISION_NUMBER = 0
 
+# SDFormat doesn't have infinite plane sizes, so we use a large number instead.
+INFINITE_PLANE_SIZE = 1e6
+
 
 def mjcf_geom_to_sdf(geom):
     """
@@ -79,7 +82,10 @@ def mjcf_geom_to_sdf(geom):
         sdf_geometry.set_type(sdf.GeometryType.SPHERE)
     elif geom.type == "plane":
         plane = sdf.Plane()
-        plane.set_size(Vector2d(geom.size[0] * 2, geom.size[1] * 2))
+        geom_size = []
+        for sz in geom.size[:2]:
+            geom_size.append(sz * 2 if sz > 0 else INFINITE_PLANE_SIZE)
+        plane.set_size(Vector2d(*geom_size))
         sdf_geometry.set_plane_shape(plane)
         sdf_geometry.set_type(sdf.GeometryType.PLANE)
     else:

--- a/mjcf_to_sdformat/tests/test_add_mjcf_geometry_to_sdf.py
+++ b/mjcf_to_sdformat/tests/test_add_mjcf_geometry_to_sdf.py
@@ -136,6 +136,17 @@ class GeometryTest(unittest.TestCase):
         assert_allclose([x_size * 2, y_size * 2],
                         su.vec2d_to_list(sdf_geom.plane_shape().size()))
 
+    def test_infinite_plane(self):
+        mujoco = mjcf.RootElement(model="test")
+        body = mujoco.worldbody.add('body')
+        geom = body.add('geom', type="plane", size=[0, 0, 1])
+        sdf_geom = geometry_conv.mjcf_geom_to_sdf(geom)
+
+        self.assertEqual(sdf.GeometryType.PLANE, sdf_geom.type())
+        self.assertNotEqual(None, sdf_geom.plane_shape())
+        assert_allclose([1e6, 1e6],
+                        su.vec2d_to_list(sdf_geom.plane_shape().size()))
+
     def test_sphere(self):
         radius = 5.
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
A size of [0, 0] is interpreted as an infinite plane for the purpose of visualization in Mujoco, but Gazebo treats it a size of 0, so instead, we use a very large size.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
