### PR TITLE
Load MJCF files with `escape_separators=True`

### DIFF
--- a/mjcf_to_sdformat/mjcf_to_sdformat/mjcf_to_sdformat.py
+++ b/mjcf_to_sdformat/mjcf_to_sdformat/mjcf_to_sdformat.py
@@ -27,7 +27,7 @@ def mjcf_file_to_sdformat(input_file, output_file, export_world_plugins=True):
     :param str output_file: Path to output SDFormat file.
     :param str export_world_plugins: If true SDFormat will export world plugins
     """
-    mjcf_model = mjcf.from_path(input_file)
+    mjcf_model = mjcf.from_path(input_file, escape_separators=True)
     physics = mujoco.Physics.from_xml_path(input_file)
 
     root = sdf.Root()


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This ensures that roundtrip tests where we convert an SDFormat file to
MJCF and then back to SDFormat don't fail when reading the MJCF file.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
