### PR TITLE
mjcf_to_sdformat: set //model/self_collide to true

### DIFF
--- a/mjcf_to_sdformat/mjcf_to_sdformat/converters/world.py
+++ b/mjcf_to_sdformat/mjcf_to_sdformat/converters/world.py
@@ -43,6 +43,7 @@ def mjcf_worldbody_to_sdf(mjcf_root, physics, world,
         model.set_name(mjcf_root.model)
     else:
         model.set_name("model")
+    model.set_self_collide(True)
 
     modifiers = MjcfModifiers(mjcf_root)
 


### PR DESCRIPTION
# 🦟 Bug fix

Allows contact between links after converting from MJCF -> SDFormat

## Summary

When converting from MJCF to SDFormat, all links are placed in the same model. With this arrangement, no contacts are possible unless `//model/self_collide` is set to True. Since it defaults to False, set it to True explicitly.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
