### PR TITLE
Prevent Visual geoms from colliding with other geoms

### DIFF
--- a/sdformat_to_mjcf/sdformat_to_mjcf/converters/geometry.py
+++ b/sdformat_to_mjcf/sdformat_to_mjcf/converters/geometry.py
@@ -131,4 +131,8 @@ def add_visual(body, vis):
     pose = su.graph_resolver.resolve_pose(sem_pose)
     geom = add_geometry(body, vis.name(), pose, vis.geometry())
     geom.group = VISUAL_GEOM_GROUP
+    # Visual geoms do not collide with any other geom, so we set their contype
+    # and conaffinity to 0.
+    geom.contype = 0
+    geom.conaffinity = 0
     return geom

--- a/sdformat_to_mjcf/tests/test_add_geometry.py
+++ b/sdformat_to_mjcf/tests/test_add_geometry.py
@@ -198,6 +198,8 @@ class CollisionTest(helpers.TestCase):
         assert_allclose([1., 2., 3.], mj_geom.pos)
         assert_allclose([90., 60., 45.], mj_geom.euler)
         self.assertEqual(geometry_conv.COLLISION_GEOM_GROUP, mj_geom.group)
+        self.assertIsNone(mj_geom.contype)
+        self.assertIsNone(mj_geom.conaffinity)
 
 
 class VisualTest(helpers.TestCase):
@@ -219,6 +221,8 @@ class VisualTest(helpers.TestCase):
         assert_allclose([1., 2., 3.], mj_geom.pos)
         assert_allclose([90., 60., 45.], mj_geom.euler)
         self.assertEqual(geometry_conv.VISUAL_GEOM_GROUP, mj_geom.group)
+        self.assertEqual(0, mj_geom.contype)
+        self.assertEqual(0, mj_geom.conaffinity)
 
 
 class GeometryIntegrationTest(unittest.TestCase):


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
Currently, even though we set group numbers on collision and visual geoms to display only the visuals, they still take part in the collision detection process and collide with any other geom. Setting the `contype` and `conaffinity` to 0 will ensure that they don't collide with any other geom.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
