### PR TITLE
Fix code coverage generation

### DIFF
--- a/sdformat_mjcf/tox.ini
+++ b/sdformat_mjcf/tox.ini
@@ -20,7 +20,7 @@ commands =
     check-manifest --ignore 'tox.ini,tests/**'
     python setup.py check -m -s
     python3 -m flake8 .
-    coverage run -m unittest {posargs}
+    coverage run --source sdformat_mjcf -m unittest {posargs}
     coverage xml
 
 [flake8]


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
Since #74 , codecov reports have been broken. They contain coverage for test files, which we don't care about, but do not contain coverage for the `sdformat_mjcf` package. I believe this is because we now test the installed package instead of the working directory, so adding the `--source` flag to `coverage run` appears to be necessary.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.