### PR TITLE
MJCF to SDFormat: Remove duplicate light added to the world

### DIFF
--- a/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/world.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/world.py
@@ -16,7 +16,6 @@ from ignition.math import Vector3d
 
 from sdformat_mjcf.mjcf_to_sdformat.converters.joint import (mjcf_joint_to_sdf,
                                                              add_fixed_joint)
-from sdformat_mjcf.mjcf_to_sdformat.converters.light import mjcf_light_to_sdf
 from sdformat_mjcf.mjcf_to_sdformat.converters.link import mjcf_body_to_sdf
 from sdformat_mjcf.mjcf_to_sdformat.converters.sensor import (
     mjcf_camera_sensor_to_sdf, mjcf_accelerometer_gyro_sensor_to_sdf,
@@ -50,11 +49,6 @@ def mjcf_worldbody_to_sdf(mjcf_root, physics, world,
     modifiers = MjcfModifiers(mjcf_root)
 
     model_static = sdf.Model()
-
-    for light in mjcf_root.worldbody.light:
-        modifiers.apply_modifiers_to_element(light)
-        light_sdf = mjcf_light_to_sdf(light)
-        world.add_light(light_sdf)
 
     link = mjcf_body_to_sdf(mjcf_root.worldbody, physics, modifiers=modifiers)
     model_static.set_name(su.find_unique_name(

--- a/sdformat_mjcf/tests/mjcf_to_sdformat/test_add_mjcf_worldbody_to_sdf.py
+++ b/sdformat_mjcf/tests/mjcf_to_sdformat/test_add_mjcf_worldbody_to_sdf.py
@@ -264,8 +264,10 @@ class ModelTest(unittest.TestCase):
         assert_allclose([0, 0, 0],
                         su.vec3d_to_list(collision_4.raw_pose().rot().euler()))
 
-        self.assertEqual(1, world.light_count())
-        light_1 = world.light_by_index(0)
+        self.assertEqual(0, world.light_count())
+        static_model = world.model_by_name("static")
+        self.assertEqual(1, static_model.link_count())
+        light_1 = static_model.link_by_index(0).light_by_index(0)
         self.assertNotEqual(None, light_1)
         self.assertEqual(0, light_1.constant_attenuation_factor())
         self.assertEqual(0.01, light_1.linear_attenuation_factor())


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
When there is a light directly under `<worldbody>`, we currently create a light in `<world>` and in the static model. This PR removes the light in `<world>`. We could remove the one in the static model, but this seemed like the easier option.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
