### PR TITLE
Set spotlight inner/outer angles and falloff to match Gazebo

### DIFF
--- a/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/light.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/light.py
@@ -76,16 +76,16 @@ def mjcf_light_to_sdf(light):
 
     def set_spot_light(light, light_sdf):
         light_sdf.set_type(sdf.LightType.SPOT)
-        if light.cutoff is not None:
-            # always in degrees regardless of the global angle setting.
-            light_sdf.set_spot_inner_angle(
-                Angle(light.cutoff * math.pi / 180.0))
-        else:
-            light_sdf.set_spot_inner_angle(Angle(45 * math.pi / 180.0))
-        if light.exponent is not None:
-            light_sdf.set_spot_falloff(light.exponent)
-        else:
-            light_sdf.set_spot_falloff(10)
+        # The settings for inner_angle, outer_angle, and falloff were
+        # determined experimentally.
+        light_sdf.set_spot_inner_angle(Angle(0))
+
+        # always in degrees regardless of the global angle setting.
+        cutoff = su.get_value_or_default(light.cutoff, 45)
+        light_sdf.set_spot_outer_angle(Angle(math.radians(cutoff * 2)))
+
+        exponent = su.get_value_or_default(light.exponent, 10)
+        light_sdf.set_spot_falloff(exponent * 2 / 10.0)
 
     if light.directional is not None:
         if light.directional == "true":

--- a/sdformat_mjcf/src/sdformat_mjcf/utils/sdf_utils.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/utils/sdf_utils.py
@@ -222,6 +222,20 @@ def get_asset_filename_on_disk(asset):
         return file.get_vfs_filename()
 
 
+def get_value_or_default(val, default_val):
+    """
+    Returns the value of `val` if it's not None, otherwise returns the passed
+    in default value.
+    :param any val: Any variable that maybe None
+    :param any default_val: The default value.
+    :return: The value or it's not None, otherwise the default value
+    :rtype: any
+    """
+    if val is None:
+        return default_val
+    return val
+
+
 class GraphResolverImplBase:
     """Interface for graph resolver implementors"""
 

--- a/sdformat_mjcf/tests/mjcf_to_sdformat/test_add_mjcf_light_to_sdf.py
+++ b/sdformat_mjcf/tests/mjcf_to_sdformat/test_add_mjcf_light_to_sdf.py
@@ -40,8 +40,9 @@ class LightTest(unittest.TestCase):
         self.assertEqual(Color(0.3, 0.3, 0.3), sdf_light.specular())
         self.assertEqual(sdf.LightType.SPOT, sdf_light.type())
         self.assertEqual(Vector3d(0, 0, -1), sdf_light.direction())
-        self.assertAlmostEqual(45, sdf_light.spot_inner_angle().degree())
-        self.assertEqual(10, sdf_light.spot_falloff())
+        self.assertAlmostEqual(0, sdf_light.spot_inner_angle().degree())
+        self.assertAlmostEqual(90, sdf_light.spot_outer_angle().degree())
+        self.assertEqual(2, sdf_light.spot_falloff())
         self.assertTrue(sdf_light.light_on())
 
     def test_light(self):
@@ -96,8 +97,9 @@ class LightTest(unittest.TestCase):
         self.assertEqual(Color(0.2, 0.2, 0.2), sdf_light.specular())
         self.assertEqual(sdf.LightType.SPOT, sdf_light.type())
         self.assertEqual(Vector3d(0, -1, -1), sdf_light.direction())
-        self.assertAlmostEqual(40, sdf_light.spot_inner_angle().degree())
-        self.assertEqual(5, sdf_light.spot_falloff())
+        self.assertAlmostEqual(0, sdf_light.spot_inner_angle().degree())
+        self.assertAlmostEqual(80, sdf_light.spot_outer_angle().degree())
+        self.assertEqual(1, sdf_light.spot_falloff())
         self.assertTrue(sdf_light.light_on())
 
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

For the following mjcf file, 
```xml
<mujoco model="light_test">
  <asset>
    <texture name="grid" type="2d" builtin="flat" mark="cross" width="256" height="256"/>
    <material name="grid" texture="grid" texrepeat="2 2" texuniform="true"/>
  </asset>
  <worldbody>
    <geom name="floor" size="4 4 0.005" type="plane" material="grid"/>
    <light name="spotlight" pos="0 0 2" dir="0 0 -1" cutoff="45" castshadow="false" exponent="0"/>
    <geom name="box" size="0.5 0.5 0.5" type="box" pos="0 0 0.5" rgba="0 1 0 1"/>
  </worldbody>
</mujoco>
```

Mujoco displays:
![image](https://user-images.githubusercontent.com/206116/173916780-05ea35a7-6b55-47a8-9562-324cb688373e.png)

And before the fix, gz-sim displays:
![image](https://user-images.githubusercontent.com/206116/173916991-fe4849d1-8c93-42bb-ba62-96354600f550.png)

After this PR, gz-sim displays:
![image](https://user-images.githubusercontent.com/206116/173923691-2f8ebbbe-866f-46a3-bb09-a17065ce58f8.png)

With exponent set to 10, 
Mujoco displays:
![image](https://user-images.githubusercontent.com/206116/173917579-d1ac48e4-39ca-46df-9593-4ab37cadcf31.png)

Before the fix, gz-sim displays the same image as before. After this PR, it displays:
![image](https://user-images.githubusercontent.com/206116/173923577-fc09430b-0db0-4d77-ba3e-66f6d32565fa.png)

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
