### PR TITLE
Set the default color of geoms according to the MJCF spec

### DIFF
--- a/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/material.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/material.py
@@ -76,4 +76,9 @@ def mjcf_material_to_sdf(geom):
         material.set_specular(su.rgba_to_color(geom.rgba))
         return material
 
+    if geom.material is None and geom.rgba is None:
+        material.set_diffuse(su.rgba_to_color([0.5, 0.5, 0.5, 1]))
+        material.set_ambient(su.rgba_to_color([0.5, 0.5, 0.5, 1]))
+        material.set_specular(su.rgba_to_color([0.5, 0.5, 0.5, 1]))
+
     return material

--- a/sdformat_mjcf/tests/mjcf_to_sdformat/test_mjcf_material_to_sdf.py
+++ b/sdformat_mjcf/tests/mjcf_to_sdformat/test_mjcf_material_to_sdf.py
@@ -102,6 +102,28 @@ class MaterialTest(unittest.TestCase):
         self.assertNotEqual(None, workflow)
         self.assertEqual("tennis_ball.png", workflow.albedo_map())
 
+    def test_no_material(self):
+        mjcf_string = """
+        <mujoco>
+            <worldbody>
+                <geom type="box" size="1 1 1"/>
+            </worldbody>
+        </mujoco>
+        """
+        mjcf_model = mjcf.from_xml_string(mjcf_string)
+        physics = mujoco.Physics.from_xml_string(mjcf_string)
+
+        world = sdf.World()
+        world.set_name("default")
+
+        mjcf_worldbody_to_sdf(mjcf_model, physics, world)
+        static_model = world.model_by_name("static")
+        box_mat = static_model.link_by_index(0).visual_by_index(0).material()
+        self.assertEqual(Color(0.5, 0.5, 0.5, 1.0), box_mat.diffuse())
+        self.assertEqual(Color(0.5, 0.5, 0.5, 1.0), box_mat.ambient())
+        self.assertEqual(Color(0.5, 0.5, 0.5, 1.0), box_mat.specular())
+        self.assertEqual(Color(0, 0, 0, 1.0), box_mat.emissive())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# 🦟 Bug fix
## Summary
The default rgba value of a geom is "0.5 0.5 0.5 1" (https://mujoco.readthedocs.io/en/latest/XMLreference.html#body-geom)
For the following MJCF file
```xml
<mujoco>
  <worldbody>
    <geom type="box" size="1 1 1"/>
  </worldbody>
</mujoco>
```
Mujoco displays:
![image](https://user-images.githubusercontent.com/206116/173930254-8ddf7e88-de33-4d3d-83ee-0a5a5d65cc71.png)

Before this PR, gz-sim displays
![image](https://user-images.githubusercontent.com/206116/173930096-24dc0da1-75e8-4370-b690-ae72bd03f124.png)

After this PR, gz-sim displays
![image](https://user-images.githubusercontent.com/206116/173930166-9cece2e2-feb0-47bb-afee-fd9815f7e585.png)


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
