### PR TITLE
mjcf->sdformat sliding friction

### DIFF
--- a/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/geometry.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/geometry.py
@@ -150,4 +150,6 @@ def mjcf_collision_to_sdf(geom):
         col.set_geometry(sdf_geometry)
     else:
         return None
+    if geom.friction is not None:
+        col.surface().friction().ode().set_mu(geom.friction[0])
     return col

--- a/sdformat_mjcf/tests/mjcf_to_sdformat/test_add_mjcf_geometry_to_sdf.py
+++ b/sdformat_mjcf/tests/mjcf_to_sdformat/test_add_mjcf_geometry_to_sdf.py
@@ -157,6 +157,18 @@ class GeometryTest(unittest.TestCase):
         self.assertEqual(radius, sdf_geom.sphere_shape().radius())
 
 
+class SurfaceTest(unittest.TestCase):
+    def test_friction(self):
+        mjcf_model = mjcf.from_path(
+            str(TEST_RESOURCES_DIR / "test_mujoco.xml"))
+
+        sdf_collision = geometry_conv.mjcf_collision_to_sdf(
+            mjcf_model.worldbody.geom[0])
+        self.assertIsNotNone(sdf_collision)
+
+        self.assertEqual(0.9, sdf_collision.surface().friction().ode().mu())
+
+
 class VisualTest(unittest.TestCase):
     def test_basic_visual_attributes(self):
         radius = 5.

--- a/sdformat_mjcf/tests/mjcf_to_sdformat/test_defaults.py
+++ b/sdformat_mjcf/tests/mjcf_to_sdformat/test_defaults.py
@@ -138,6 +138,37 @@ class DefaultsTest(unittest.TestCase):
         shape6_sphere = visual_shape6.geometry().sphere_shape()
         self.assertEqual(0.5, shape6_sphere.radius())
 
+    def test_default_friction(self):
+        filename = str(TEST_RESOURCES_DIR / "tennis_ball.xml")
+        mjcf_model = mjcf.from_path(filename)
+        physics = mujoco.Physics.from_xml_path(filename)
+
+        world = sdf.World()
+        world.set_name("default")
+
+        mjcf_worldbody_to_sdf(mjcf_model, physics, world)
+
+        self.assertEqual("default", world.name())
+        self.assertEqual(2, world.model_count())
+        model = world.model_by_index(0)
+        self.assertNotEqual(None, model)
+        self.assertEqual(1, model.link_count())
+        self.assertTrue(model.static())
+
+        model = world.model_by_index(1)
+        self.assertNotEqual(None, model)
+        self.assertEqual(1, model.link_count())
+        link = model.link_by_index(0)
+        self.assertNotEqual(None, link)
+
+        collision = link.collision_by_index(0)
+        self.assertEqual(sdf.GeometryType.SPHERE, collision.geometry().type())
+        sphere_shape = collision.geometry().sphere_shape()
+        self.assertNotEqual(None, sphere_shape)
+        self.assertEqual(0.03, sphere_shape.radius())
+        surface = collision.surface()
+        self.assertEqual(0.5, surface.friction().ode().mu())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/sdformat_mjcf/tests/resources/test_mujoco.xml
+++ b/sdformat_mjcf/tests/resources/test_mujoco.xml
@@ -12,7 +12,7 @@
    <worldbody>
       <light diffuse=".5 .5 .5" pos="0 0 3" dir="0 0 -1" cutoff="45" exponent="10"
              attenuation="0.0 0.01 0.001" specular="0.2 0.2 0.2"/>
-      <geom type="plane" size="1 1 0.1" rgba=".9 0 0 1"/>
+      <geom type="plane" size="1 1 0.1" rgba=".9 0 0 1" friction="0.9 0.001 0.001"/>
       <geom name="rail1" type="capsule" pos="0  .07 1" zaxis="1 0 0" size="0.02 2"/>
       <camera name="fixed" pos="0 -6 2" zaxis="0 -1 0"/>
       <camera name="target_camera" pos="0 -6 2" zaxis="0 -1 0" target="body2"/>


### PR DESCRIPTION
# 🎉 New feature

Follow-up to https://github.com/gazebosim/gz-mujoco/pull/70

## Summary

This supports translation of sliding friction parameters from MJCF to SDFormat, the reverse of #70. It requires https://github.com/gazebosim/sdformat/pull/1049 and will remain in draft state until that is merged.

## Test it

* Run tests
* Convert [tests/resources/friction_demo.sdf](https://github.com/gazebosim/gz-mujoco/blob/main/sdformat_mjcf/tests/resources/friction_demo.sdf) to MJCF and then back again and run both world files in gazebo to compare the sliding behavior.

~~~
sdformat2mjcf friction_demo.sdf friction_demo_1.xml
mjcf2sdformat friction_demo_1.xml friction_demo_2.sdf
~~~

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
