### PR TITLE
MJCF to SDFormat: Export texture files

### DIFF
--- a/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/material.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/material.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 import logging
+import os
 
 import sdformat as sdf
 
 import sdformat_mjcf.utils.sdf_utils as su
+
+TEXTURE_OUTPUT_DIR = "materials/textures"
 
 
 def mjcf_material_to_sdf(geom):
@@ -66,7 +69,8 @@ def mjcf_material_to_sdf(geom):
                 workflow = sdf.PbrWorkflow()
                 workflow.set_type(sdf.PbrWorkflowType.METAL)
                 filename = su.get_asset_filename_on_disk(geom.material.texture)
-                workflow.set_albedo_map(filename)
+                workflow.set_albedo_map(
+                    os.path.join(TEXTURE_OUTPUT_DIR, filename))
                 pbr.set_workflow(workflow.type(), workflow)
                 material.set_pbr_material(pbr)
 

--- a/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/mjcf_to_sdformat.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/mjcf_to_sdformat.py
@@ -23,6 +23,8 @@ from sdformat_mjcf.mjcf_to_sdformat.converters.world import (
     mjcf_worldbody_to_sdf,
 )
 from sdformat_mjcf.mjcf_to_sdformat.converters.geometry import MESH_OUTPUT_DIR
+from sdformat_mjcf.mjcf_to_sdformat.converters.material import (
+    TEXTURE_OUTPUT_DIR)
 
 import sdformat_mjcf.utils.sdf_utils as su
 
@@ -51,9 +53,9 @@ def mjcf_file_to_sdformat(input_file, output_file, export_world_plugins=True):
     # Export all assets to the directory that contains the output_file
     out_dir = os.path.dirname(output_file)
 
-    # TODO (azeey) export textures as well
     asset_output = {
         MESH_OUTPUT_DIR: list(mjcf_model.asset.mesh),
+        TEXTURE_OUTPUT_DIR: list(mjcf_model.asset.texture),
     }
 
     for sub_dir, assets in asset_output.items():

--- a/sdformat_mjcf/tests/mjcf_to_sdformat/test_mjcf_material_to_sdf.py
+++ b/sdformat_mjcf/tests/mjcf_to_sdformat/test_mjcf_material_to_sdf.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 
 from ignition.math import Color
@@ -21,6 +22,7 @@ from dm_control import mujoco
 
 from sdformat_mjcf.mjcf_to_sdformat.converters.material import (
     mjcf_material_to_sdf,
+    TEXTURE_OUTPUT_DIR
 )
 from sdformat_mjcf.mjcf_to_sdformat.converters.world import (
     mjcf_worldbody_to_sdf,
@@ -100,7 +102,8 @@ class MaterialTest(unittest.TestCase):
         self.assertNotEqual(None, pbr)
         workflow = pbr.workflow(sdf.PbrWorkflowType.METAL)
         self.assertNotEqual(None, workflow)
-        self.assertEqual("tennis_ball.png", workflow.albedo_map())
+        expected_path = os.path.join(TEXTURE_OUTPUT_DIR, "tennis_ball.png")
+        self.assertEqual(expected_path, workflow.albedo_map())
 
     def test_no_material(self):
         mjcf_string = """

--- a/sdformat_mjcf/tests/mjcf_to_sdformat/test_mjcf_to_sdformat.py
+++ b/sdformat_mjcf/tests/mjcf_to_sdformat/test_mjcf_to_sdformat.py
@@ -23,6 +23,8 @@ from ignition.math import Vector3d
 from sdformat_mjcf.mjcf_to_sdformat.mjcf_to_sdformat import (
     mjcf_file_to_sdformat)
 from sdformat_mjcf.mjcf_to_sdformat.converters.geometry import MESH_OUTPUT_DIR
+from sdformat_mjcf.mjcf_to_sdformat.converters.material import (
+    TEXTURE_OUTPUT_DIR)
 
 from tests.helpers import get_resources_dir
 
@@ -31,7 +33,7 @@ TEST_RESOURCES_DIR = get_resources_dir()
 
 class MjcfFileConversion(unittest.TestCase):
 
-    def test_mesh_output(self):
+    def test_mesh_and_texture_output(self):
         input_file = str(TEST_RESOURCES_DIR / "mug.xml")
         with tempfile.TemporaryDirectory() as temp_dir:
             output_file = os.path.join(temp_dir, "mug.sdf")
@@ -45,20 +47,28 @@ class MjcfFileConversion(unittest.TestCase):
             mug_model = world.model_by_name("model_for_mug")
             mug_link = mug_model.link_by_name("mug")
 
-            def check_geometry(sdf_geom):
+            def check_for_mesh(sdf_geom):
                 self.assertEqual(sdf.GeometryType.MESH, sdf_geom.type())
                 mesh_shape = sdf_geom.mesh_shape()
                 self.assertIsNotNone(mesh_shape)
-                self.assertEqual(os.path.join(MESH_OUTPUT_DIR, "mug.obj"),
-                                 mesh_shape.uri())
+                expected_path = os.path.join(MESH_OUTPUT_DIR, "mug.obj")
+                self.assertEqual(expected_path, mesh_shape.uri())
+                self.assertTrue(
+                    os.path.exists(os.path.join(temp_dir, expected_path)))
 
             mug_visual = mug_link.visual_by_index(0)
             self.assertEqual(Vector3d(pi / 2, 0, 0),
                              mug_visual.raw_pose().rot().euler())
-            check_geometry(mug_visual.geometry())
+            check_for_mesh(mug_visual.geometry())
+            pbr = mug_visual.material().pbr_material()
+            workflow = pbr.workflow(sdf.PbrWorkflowType.METAL)
+            expected_texture_path = os.path.join(TEXTURE_OUTPUT_DIR, "mug.png")
+            self.assertEqual(expected_texture_path, workflow.albedo_map())
+            self.assertTrue(
+                os.path.exists(os.path.join(temp_dir, expected_texture_path)))
 
             mug_collision = mug_link.collision_by_index(0)
-            check_geometry(mug_collision.geometry())
+            check_for_mesh(mug_collision.geometry())
             self.assertEqual(Vector3d(pi / 2, 0, 0),
                              mug_collision.raw_pose().rot().euler())
 


### PR DESCRIPTION
# 🎉 New feature

## Summary
Exports textures to `materials/textures` subdirectory of the output files parent directory.

## Test it
* test_mjcf_to_sdformat.py

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
