### PR TITLE
Fix default class and names so generated xml doesn't contain `/`

### DIFF
--- a/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/mjcf_to_sdformat.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/mjcf_to_sdformat.py
@@ -36,7 +36,7 @@ def mjcf_file_to_sdformat(input_file, output_file, export_world_plugins=True):
     :param str output_file: Path to output SDFormat file.
     :param str export_world_plugins: If true SDFormat will export world plugins
     """
-    mjcf_model = mjcf.from_path(input_file, escape_separators=True)
+    mjcf_model = mjcf.from_path(input_file)
     physics = mujoco.Physics.from_xml_path(input_file)
 
     root = sdf.Root()

--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/joint.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/joint.py
@@ -69,7 +69,8 @@ def add_joint(body, joint):
     :rtype: mjcf.Element
     """
     if isinstance(joint, FreeJoint):
-        return body.add("freejoint")
+        return body.add("freejoint",
+                        name=su.find_unique_name(body, "joint", "freejoint"))
 
     if isinstance(joint, StaticFixedJoint):
         # The pose of this joint can be chosen arbitrarily since the purpose

--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/sdformat_to_mjcf.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/sdformat_to_mjcf.py
@@ -34,6 +34,7 @@ def sdformat_file_to_mjcf(input_file, output_file):
         return 1
     else:
         mjcf_root = add_root(root)
+        mjcf_root.default.dclass = "unused"
         output_dir, file_name = os.path.split(os.path.abspath(output_file))
         export_with_assets(mjcf_root, output_dir, file_name)
         return 0

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_root.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_root.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import tempfile
 import unittest
+import os
 from math import pi
 
 import sdformat as sdf
@@ -20,7 +22,11 @@ from ignition.math import Pose3d
 from dm_control import mjcf
 
 from sdformat_mjcf.sdformat_to_mjcf.converters.root import add_root
+from sdformat_mjcf.sdformat_to_mjcf.sdformat_to_mjcf import (
+    sdformat_file_to_mjcf)
 from tests import helpers
+
+TEST_RESOURCES_DIR = helpers.get_resources_dir()
 
 
 class RootTest(helpers.TestCase):
@@ -64,6 +70,15 @@ class RootTest(helpers.TestCase):
         with self.assertRaises(RuntimeError,
                                msg="One model or one world is supported"):
             add_root(root)
+
+    def test_parsing_mjcf_output(self):
+        model_file = str(TEST_RESOURCES_DIR / "double_pendulum.sdf")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_file = os.path.join(temp_dir, "out.xml")
+            sdformat_file_to_mjcf(model_file, output_file)
+            print(open(output_file).read())
+            model = mjcf.from_path(output_file)
+            self.assertIsNotNone(model)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
I tried to convert `dm_control/dm_control/suite/dog.xml` and encountered an error 
```
FileNotFoundError: Line 166: error while parsing element <mesh>: during initialization of attribute 'file' of element <mesh>: [Errno 2] No such file or directory: 'dog_assets\\/BONEC_1.stl'
```

The problem seem is that we are telling `pymjcf` to escape `/` characters and that is interfering with the slash in file paths. The solution here is to go back to ensure that the `/` is not generated in our output MJCF files.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
