### PR TITLE
Handle default geom types and mesh scales

### DIFF
--- a/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/geometry.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/geometry.py
@@ -37,6 +37,7 @@ def mjcf_geom_to_sdf(geom):
     :rtype: sdf.Geometry
     """
     sdf_geometry = sdf.Geometry()
+    is_default_type = geom.type is None and geom.mesh is None
     if geom.type == "box":
         box = sdf.Box()
         if geom.fromto is None:
@@ -79,7 +80,7 @@ def mjcf_geom_to_sdf(geom):
                 "Encountered unsupported shape type attribute 'fromto'")
         sdf_geometry.set_ellipsoid_shape(ellipsoid)
         sdf_geometry.set_type(sdf.GeometryType.ELLIPSOID)
-    elif geom.type == "sphere":
+    elif geom.type == "sphere" or is_default_type:
         sphere = sdf.Sphere()
         sphere.set_radius(geom.size[0])
         sdf_geometry.set_sphere_shape(sphere)
@@ -92,10 +93,11 @@ def mjcf_geom_to_sdf(geom):
         plane.set_size(Vector2d(*geom_size))
         sdf_geometry.set_plane_shape(plane)
         sdf_geometry.set_type(sdf.GeometryType.PLANE)
-    elif geom.type == "mesh":
+    elif geom.type == "mesh" or geom.mesh is not None:
         mj_mesh = geom.mesh
         mesh = sdf.Mesh()
-        mesh.set_scale(su.list_to_vec3d(mj_mesh.scale))
+        scale = su.get_value_or_default(mj_mesh.scale, [1, 1, 1])
+        mesh.set_scale(su.list_to_vec3d(scale))
         mesh.set_uri(
             os.path.join(MESH_OUTPUT_DIR,
                          su.get_asset_filename_on_disk(mj_mesh)))

--- a/sdformat_mjcf/tests/mjcf_to_sdformat/test_add_mjcf_geometry_to_sdf.py
+++ b/sdformat_mjcf/tests/mjcf_to_sdformat/test_add_mjcf_geometry_to_sdf.py
@@ -137,6 +137,27 @@ class GeometryTest(unittest.TestCase):
         self.assertIsNotNone(mesh_shape)
         self.assertEqual(Vector3d(0.01, 0.01, 0.01), mesh_shape.scale())
 
+    def test_mesh_without_type(self):
+        test_mjcf = f"""
+        <mujoco model="mug">
+            <asset>
+                <mesh file="{TEST_RESOURCES_DIR / "mug.obj"}"/>
+            </asset>
+            <worldbody>
+                <geom name="mug" mesh="mug"/>
+            </worldbody>
+        </mujoco>
+        """
+        print(test_mjcf)
+        mjcf_model = mjcf.from_xml_string(test_mjcf)
+        self.assertIsNotNone(mjcf_model)
+        geom = mjcf_model.find("geom", "mug")
+        self.assertIsNotNone(geom)
+        sdf_geom = geometry_conv.mjcf_geom_to_sdf(geom)
+        self.assertEqual(sdf.GeometryType.MESH, sdf_geom.type())
+        mesh_shape = sdf_geom.mesh_shape()
+        self.assertIsNotNone(mesh_shape)
+
     def test_plane(self):
         x_size = 5.
         y_size = 10.
@@ -164,6 +185,16 @@ class GeometryTest(unittest.TestCase):
         radius = 5.
 
         geom = self.body.add('geom', type="sphere", size=[radius])
+        sdf_geom = geometry_conv.mjcf_geom_to_sdf(geom)
+
+        self.assertEqual(sdf.GeometryType.SPHERE, sdf_geom.type())
+        self.assertNotEqual(None, sdf_geom.sphere_shape())
+        self.assertEqual(radius, sdf_geom.sphere_shape().radius())
+
+    def test_no_type(self):
+        radius = 5.
+
+        geom = self.body.add('geom', size=[radius])
         sdf_geom = geometry_conv.mjcf_geom_to_sdf(geom)
 
         self.assertEqual(sdf.GeometryType.SPHERE, sdf_geom.type())

--- a/sdformat_mjcf/tests/mjcf_to_sdformat/test_add_mjcf_geometry_to_sdf.py
+++ b/sdformat_mjcf/tests/mjcf_to_sdformat/test_add_mjcf_geometry_to_sdf.py
@@ -148,7 +148,6 @@ class GeometryTest(unittest.TestCase):
             </worldbody>
         </mujoco>
         """
-        print(test_mjcf)
         mjcf_model = mjcf.from_xml_string(test_mjcf)
         self.assertIsNotNone(mjcf_model)
         geom = mjcf_model.find("geom", "mug")


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
While trying to convert `dm_control/dm_control/suite/dog.xml` I noticed that we are not handling geoms without a `type` attribute. The default value of geom types is `sphere` according to the MJCF docs.

Apparently it's also possible to specify `geom[@mesh]` without setting `type`, and this PR also addresses that. 

Finally, we were not checking if `geom[@scale]` was set when processing meshes. This PR applies the default scale if the attribute is not set.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
