### PR TITLE
Do not try to export builtin textures

### DIFF
--- a/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/mjcf_to_sdformat.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/mjcf_to_sdformat.py
@@ -61,8 +61,9 @@ def mjcf_file_to_sdformat(input_file, output_file, export_world_plugins=True):
     for sub_dir, assets in asset_output.items():
         new_dir = os.path.join(out_dir, sub_dir)
         for asset in assets:
-            filename = su.get_asset_filename_on_disk(asset)
-            if not os.path.exists(new_dir):
-                os.makedirs(new_dir)
-            with open(os.path.join(new_dir, filename), 'wb') as f:
-                f.write(util.to_binary_string(asset.file.contents))
+            if asset.file is not None:
+                filename = su.get_asset_filename_on_disk(asset)
+                if not os.path.exists(new_dir):
+                    os.makedirs(new_dir)
+                with open(os.path.join(new_dir, filename), 'wb') as f:
+                    f.write(util.to_binary_string(asset.file.contents))

--- a/sdformat_mjcf/tests/resources/mug.xml
+++ b/sdformat_mjcf/tests/resources/mug.xml
@@ -6,6 +6,8 @@
   </visual>
 
   <asset>
+    <texture name="skybox" type="skybox" builtin="gradient" rgb1=".4 .6 .8" rgb2="0 0 0"
+      width="800" height="800" mark="random" markrgb="1 1 1"/>
     <texture name="mug" file="mug.png" type="2d"/>
     <material name="mug" texture="mug" specular="1" shininess="1"/>
     <mesh file="mug.obj" scale=".01 .01 .01"/>


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
When exporting textures, if the texture is a builtin (eg. `checker`), the converter raises
```
 AttributeError: 'NoneType' object has no attribute 'prefix'
```
This PR fixes it by checking if the file attribute is present and set to a non-None value.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
