### PR TITLE
MJCF to SDFormat: Fix index generation for visuals and collisions

### DIFF
--- a/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/link.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/link.py
@@ -120,8 +120,6 @@ def mjcf_body_to_sdf(body, physics, body_parent_name=None, modifiers=None):
             link.set_inertial(inertial)
         except AttributeError:
             pass
-    NUMBER_OF_VISUAL = 0
-    NUMBER_OF_COLLISION = 0
 
     link.set_raw_pose(su.get_pose_from_mjcf(body))
 
@@ -159,11 +157,11 @@ def mjcf_body_to_sdf(body, physics, body_parent_name=None, modifiers=None):
         else:
             return su.get_pose_from_mjcf(geom).pos()
 
-    def set_visual(geom):
+    def set_visual(geom, index):
         visual = mjcf_visual_to_sdf(geom)
         if visual is not None:
             visual.set_name(su.prefix_name_with_index(
-                "visual", geom.name, NUMBER_OF_VISUAL))
+                "visual", geom.name, index))
             material = mjcf_material_to_sdf(geom)
             if material is not None:
                 visual.set_material(material)
@@ -171,26 +169,32 @@ def mjcf_body_to_sdf(body, physics, body_parent_name=None, modifiers=None):
             visual.set_raw_pose(pose)
             link.add_visual(visual)
 
-    def set_collision(geom):
+    def set_collision(geom, index):
         col = mjcf_collision_to_sdf(geom)
         if col is not None:
             col.set_name(su.prefix_name_with_index(
-                "collision", geom.name, NUMBER_OF_COLLISION))
+                "collision", geom.name, index))
             pose = Pose3d(get_position(geom), get_orientation(geom))
             col.set_raw_pose(pose)
             link.add_collision(col)
 
-    for geom in body.geom:
+    visual_index = 0
+    collision_index = 0
+    for ind, geom in enumerate(body.geom):
         if modifiers is not None:
             modifiers.apply_modifiers_to_element(geom)
         # If the group is not defined then visual and collision is added
         if geom.group is None:
-            set_visual(geom)
-            set_collision(geom)
+            set_visual(geom, visual_index)
+            set_collision(geom, collision_index)
+            visual_index += 1
+            collision_index += 1
         elif geom.group == VISUAL_GEOM_GROUP:
-            set_visual(geom)
+            set_visual(geom, visual_index)
+            visual_index += 1
         elif geom.group == COLLISION_GEOM_GROUP:
-            set_collision(geom)
+            set_collision(geom, collision_index)
+            collision_index += 1
 
     for light in body.light:
         if modifiers is not None:

--- a/sdformat_mjcf/src/sdformat_mjcf/utils/sdf_utils.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/utils/sdf_utils.py
@@ -182,7 +182,6 @@ def prefix_name_with_index(prefix, name, index):
         return prefix + NAME_DELIMITER + name
     else:
         new_name = prefix + NAME_DELIMITER + str(index)
-        index = index + 1
         return new_name
 
 

--- a/sdformat_mjcf/tests/mjcf_to_sdformat/test_add_mjcf_worldbody_to_sdf.py
+++ b/sdformat_mjcf/tests/mjcf_to_sdformat/test_add_mjcf_worldbody_to_sdf.py
@@ -309,6 +309,21 @@ class ModelTest(unittest.TestCase):
         static_model = world.model_by_name("static")
         self.assertEqual(1, static_model.link_count())
 
+    def test_add_unnamed_geoms(self):
+        filename = str(TEST_RESOURCES_DIR / "test_unnamed_geoms.xml")
+        mjcf_model = mjcf.from_path(filename)
+        physics = mjcf.Physics.from_mjcf_model(mjcf_model)
+
+        world = sdf.World()
+        world.set_name("default")
+
+        mjcf_worldbody_to_sdf(mjcf_model, physics, world)
+        model = world.model_by_name("model_for_test")
+        self.assertEqual(1, model.link_count())
+        link = model.link_by_index(0)
+        self.assertEqual(2, link.visual_count())
+        self.assertEqual(2, link.collision_count())
+
 
 class PoseTest(unittest.TestCase):
     expected_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)

--- a/sdformat_mjcf/tests/resources/test_unnamed_geoms.xml
+++ b/sdformat_mjcf/tests/resources/test_unnamed_geoms.xml
@@ -1,0 +1,9 @@
+<mujoco>
+  <worldbody>
+    <body name="test">
+      <geom type="box" size="1 1 1" />
+      <geom type="sphere" size="1" />
+    </body>
+  </worldbody>
+</mujoco>
+


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The index generation was not working properly because the variables `NUMBER_OF_VISUAL` and `NUMBER_OF_COLLISION` were not being incremented. The function `prefix_name_with_index` does increment the passed index, but it's incrementing a copy since integers are immutable in python. 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
