### PR TITLE
MJCF to SDFormat: Support defaults for assets (meshes and materials)

### DIFF
--- a/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/material.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/material.py
@@ -32,12 +32,12 @@ def mjcf_material_to_sdf(geom):
     """
     material = sdf.Material()
     if geom.material is not None:
-        material_rbga = geom.material.rgba
-        if material_rbga is None:
-            material_rbga = [1] * 4
+        material_rgba = geom.material.rgba
+        if material_rgba is None:
+            material_rgba = [1] * 4
 
-        material.set_diffuse(su.rgba_to_color(material_rbga))
-        material.set_ambient(su.rgba_to_color(material_rbga))
+        material.set_diffuse(su.rgba_to_color(material_rgba))
+        material.set_ambient(su.rgba_to_color(material_rgba))
         if geom.material.specular is not None:
             material.set_specular(
                 su.rgba_to_color([geom.material.specular] * 3 + [1]))
@@ -45,7 +45,7 @@ def mjcf_material_to_sdf(geom):
             material.set_specular(su.rgba_to_color([0.5] * 3 + [1]))
         if geom.material.emission is not None:
             emission = [geom.material.emission * color for color in
-                        geom.material.rgba[:3]]
+                        material_rgba[:3]]
             material.set_emissive(su.rgba_to_color(emission + [1]))
         else:
             material.set_emissive(su.rgba_to_color([0] * 3 + [1]))

--- a/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/world.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/world.py
@@ -113,6 +113,12 @@ def mjcf_worldbody_to_sdf(mjcf_root, physics, world,
     """
     modifiers = MjcfModifiers(mjcf_root)
 
+    for mesh_asset in mjcf_root.asset.mesh:
+        modifiers.apply_modifiers_to_element(mesh_asset)
+
+    for material_asset in mjcf_root.asset.material:
+        modifiers.apply_modifiers_to_element(material_asset)
+
     model_static = sdf.Model()
 
     link = mjcf_body_to_sdf(mjcf_root.worldbody, physics, modifiers=modifiers)

--- a/sdformat_mjcf/src/sdformat_mjcf/utils/defaults.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/utils/defaults.py
@@ -42,7 +42,7 @@ class MjcfModifiers:
         self._copy_attributes(def_elem, elem)
 
     def _get_default_class(self, elem):
-        if elem.dclass is not None:
+        if hasattr(elem, 'dclass') and elem.dclass is not None:
             return elem.dclass
 
         cur_elem = elem.parent

--- a/sdformat_mjcf/tests/mjcf_to_sdformat/test_defaults.py
+++ b/sdformat_mjcf/tests/mjcf_to_sdformat/test_defaults.py
@@ -22,6 +22,7 @@ from sdformat_mjcf.mjcf_to_sdformat.converters.world import (
 )
 
 import sdformat as sdf
+from ignition.math import Vector3d, Color
 
 from tests.helpers import get_resources_dir
 
@@ -139,6 +140,24 @@ class DefaultsTest(unittest.TestCase):
                          visual_shape6.geometry().type())
         shape6_sphere = visual_shape6.geometry().sphere_shape()
         self.assertEqual(0.5, shape6_sphere.radius())
+
+    def test_asset_defaults(self):
+        filename = str(TEST_RESOURCES_DIR / "test_asset_defaults.xml")
+        mjcf_model = mjcf.from_path(filename)
+        physics = mujoco.Physics.from_xml_path(filename)
+
+        world = sdf.World()
+        world.set_name("default")
+
+        mjcf_worldbody_to_sdf(mjcf_model, physics, world)
+        static_model = world.model_by_name("static")
+        link = static_model.link_by_index(0)
+        visual_mug = link.visual_by_name("visual_mug")
+        mesh_shape = visual_mug.geometry().mesh_shape()
+        self.assertEqual(Vector3d(0.1, 0.2, 0.3), mesh_shape.scale())
+        material = visual_mug.material()
+        self.assertEqual(Color(0.12, 0.12, 0.12, 1.0), material.emissive())
+        self.assertEqual(Color(0.34, 0.34, 0.34, 1), material.specular())
 
 
 if __name__ == "__main__":

--- a/sdformat_mjcf/tests/resources/test_asset_defaults.xml
+++ b/sdformat_mjcf/tests/resources/test_asset_defaults.xml
@@ -1,0 +1,15 @@
+<mujoco>
+  <default>
+    <mesh scale="0.1 0.2 0.3"/>
+    <material emission="0.12"/>
+  </default>
+
+  <asset>
+    <mesh file="mug.obj"/>
+    <material name="mug_mat" specular="0.34"/>
+  </asset>
+
+  <worldbody>
+    <geom name="mug" type="mesh" mesh="mug" material="mug_mat"/>
+  </worldbody>
+</mujoco>

--- a/sdformat_mjcf/tests/resources/test_defaults.xml
+++ b/sdformat_mjcf/tests/resources/test_defaults.xml
@@ -1,5 +1,7 @@
 <mujoco>
   <default>
+    <mesh scale="0.1 0.2 0.3"/>
+    <material emission="0.123"/>
     <geom rgba="0 1 0 1"/>
     <default class="walker">
       <geom type="capsule"/>
@@ -9,6 +11,11 @@
     </default>
   </default>
 
+  <asset>
+    <mesh file="mug.obj"/>
+    <material name="mug_mat" specular="0"/>
+  </asset>
+
   <worldbody>
     <geom name="floor" type="plane" conaffinity="1" pos="248 0 0" size="250 .8 .2" zaxis="0 0 1"/>
     <body name="torso" childclass="walker">
@@ -17,5 +24,7 @@
         <geom name="torso2" size="0.07 0.3" class="class_arm"/>
       </body>
     </body>
+
+    <geom name="mug" type="mesh" mesh="mug" material="mug_mat"/>
   </worldbody>
 </mujoco>


### PR DESCRIPTION
# 🎉 New feature

## Summary
Currently, we only support defaults for items under `<worldbody>`. This adds support for applying defaults to `<mesh>` and `<material>` which are under `<assets>`. This is needed to convert a non-public model that uses defaults for `<mesh>`. 

## Test it
`test_defaults.py`

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
