### PR TITLE
Shorten names of executables

### DIFF
--- a/sdformat_mjcf/README.md
+++ b/sdformat_mjcf/README.md
@@ -19,19 +19,8 @@ pip install -U pip
 pip install dm-control
 ```
 
-Install `python3-ignition-math7` from the
+Install `python3-ignition-math7` and `python3-sdformat13` from the
 [nightly](https://gazebosim.org/docs/all/release#type-of-releases) repo.
-
-Build `libsdformat` from source from the `ahcorde/python/all` branch and add
-the installation path to your `LD_LIBRARY_PATH` and `PYTHONPATH`.
-
-```
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$INSTALL_DIR/lib"
-export PYTHONPATH="$PYTHONPATH:$INSTALL_DIR/lib/python"
-```
-
-where `$INSTALL_DIR` is the installation directory you used when building
-libsdformat.
 
 Install the `sdformat-mjcf` package in "editable" mode
 
@@ -49,10 +38,10 @@ python -m unittest
 
 # Tools for converting SDFormat to MJCF
 
-Use the commnad line tool `sdformat2mjcf`:
+Use the commnad line tool `sdf2mjcf`:
 
 ```bash
-usage: sdformat2mjcf [-h] input_file output_file
+usage: sdf2mjcf [-h] input_file output_file
 
 positional arguments:
   input_file   Path to input SDFormat file (World or Model)
@@ -86,10 +75,10 @@ extract the contents and run
 
 # Tools for converting MJCF to SDFormat
 
-Use the commnad line tool `mjcf2sdformat`:
+Use the commnad line tool `mjcf2sdf`:
 
 ```bash
-usage: mjcf2sdformat [-h] [--export_world_plugins] input_file output_file
+usage: mjcf2sdf [-h] [--export_world_plugins] input_file output_file
 
 positional arguments:
   input_file            Path to input MJCF file

--- a/sdformat_mjcf/setup.py
+++ b/sdformat_mjcf/setup.py
@@ -23,8 +23,8 @@ setup(
     test_suite='tests',
     entry_points={
         'console_scripts': [
-            'sdformat2mjcf = sdformat_mjcf.sdformat_to_mjcf.cli:main',
-            'mjcf2sdformat = sdformat_mjcf.mjcf_to_sdformat.cli:main',
+            'sdf2mjcf = sdformat_mjcf.sdformat_to_mjcf.cli:main',
+            'mjcf2sdf= sdformat_mjcf.mjcf_to_sdformat.cli:main',
         ],
     },
 )


### PR DESCRIPTION
# 🎉 New feature

## Summary
Shortens executable names from `sdformat2mjcf` -> `sdf2mjcf` and `mjcf2sdformat` ->`mjcf2sdf`. Also updates documentation regarding installing sdformat from nightlies instead of building from source.

## Test it
Run `sdf2mjcf` or `mjcf2sdf`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
