### PR TITLE
Catch libsdformat exceptions

### DIFF
--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/sdformat_to_mjcf.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/sdformat_to_mjcf.py
@@ -28,9 +28,10 @@ def sdformat_file_to_mjcf(input_file, output_file):
     such as meshes will be output to the directory containing the output file.
     """
     root = sdf.Root()
-    errors = root.load(input_file)
-    if errors:
-        print(errors, file=sys.stderr)
+    try:
+        root.load(input_file)
+    except sdf.SDFErrorsException as e:
+        print(e, file=sys.stderr)
         return 1
     else:
         mjcf_root = add_root(root)

--- a/sdformat_mjcf/src/sdformat_mjcf/utils/sdf_utils.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/utils/sdf_utils.py
@@ -276,15 +276,13 @@ class GraphResolverImpl(GraphResolverImplBase):
         is resolved.
         :return: The resolved pose.
         :rtype: ignition.math.Pose3d
-        :raises RuntimeError: if an error is encountered when resolving the
-        pose.
+        :raises SDFErrorsException: if an error is encountered when resolving
+        the pose.
         """
-        pose = Pose3d()
         if relative_to is None:
-            self._handle_errors(sem_pose.resolve(pose))
+            return sem_pose.resolve()
         else:
-            self._handle_errors(sem_pose.resolve(pose, relative_to))
-        return pose
+            return sem_pose.resolve(relative_to)
 
     def resolve_axis_xyz(self, joint_axis):
         """
@@ -293,12 +291,10 @@ class GraphResolverImpl(GraphResolverImplBase):
         resolved.
         :return: The resolved xyz vector.
         :rtype: ignition.math.Vector3d
-        :raises RuntimeError: if an error is encountered when resolving the
-        vector.
+        :raises SDFErrorsException: if an error is encountered when resolving
+        the vector.
         """
-        xyz_vec = Vector3d()
-        self._handle_errors(joint_axis.resolve_xyz(xyz_vec))
-        return xyz_vec
+        return joint_axis.resolve_xyz()
 
     def resolve_parent_link_name(self, joint):
         """
@@ -306,12 +302,10 @@ class GraphResolverImpl(GraphResolverImplBase):
         :param sdformat.Joint joint: The Joint object.
         :return: The resolved name of the parent link.
         :rtype: str
-        :raises RuntimeError: if an error is encountered when resolving the
-        the link.
+        :raises SDFErrorsException: if an error is encountered when resolving
+        the the link.
         """
-        errors, parent_link_name = joint.resolve_parent_link()
-        self._handle_errors(errors)
-        return parent_link_name
+        return joint.resolve_parent_link()
 
     def resolve_child_link_name(self, joint):
         """
@@ -319,16 +313,10 @@ class GraphResolverImpl(GraphResolverImplBase):
         :param sdformat.Joint joint: The Joint object.
         :return: The resolved name of the child link.
         :rtype: str
-        :raises RuntimeError: if an error is encountered when resolving the
-        the link.
+        :raises SDFErrorsException: if an error is encountered when resolving
+        the the link.
         """
-        errors, child_link_name = joint.resolve_child_link()
-        self._handle_errors(errors)
-        return child_link_name
-
-    def _handle_errors(self, errors):
-        if errors:
-            raise RuntimeError("\n".join(str(err) for err in errors))
+        return joint.resolve_child_link()
 
 
 class GraphResolver:

--- a/sdformat_mjcf/tests/mjcf_to_sdformat/test_mjcf_to_sdformat.py
+++ b/sdformat_mjcf/tests/mjcf_to_sdformat/test_mjcf_to_sdformat.py
@@ -41,8 +41,7 @@ class MjcfFileConversion(unittest.TestCase):
 
             self.assertTrue(os.path.exists(output_file))
             root = sdf.Root()
-            errors = root.load(output_file)
-            self.assertEqual(0, len(errors))
+            root.load(output_file)
             world = root.world_by_index(0)
             mug_model = world.model_by_name("model_for_mug")
             mug_link = mug_model.link_by_name("mug")

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_link.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_link.py
@@ -218,8 +218,7 @@ class LinkIntegration(unittest.TestCase):
         </sdf>""".format(*self.expected_pos, *self.expected_euler)
 
         root = sdf.Root()
-        errors = root.load_sdf_string(model_string)
-        self.assertEqual(0, len(errors))
+        root.load_sdf_string(model_string)
         mjcf_root = add_root(root)
         mj_link = mjcf_root.find("body", "L1")
         assert_allclose(self.expected_pos, mj_link.pos)

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_model.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_model.py
@@ -187,8 +187,7 @@ class ModelIntegrationTest(unittest.TestCase):
         </sdf>
         """
         root = sdf.Root()
-        errors = root.load_sdf_string(test_model_sdf)
-        self.assertEqual(0, len(errors))
+        root.load_sdf_string(test_model_sdf)
         mj_root = add_root(root)
         self.assertIsNotNone(mj_root)
         mj_link1 = mj_root.find("body", "link1")

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_name_collisions.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_name_collisions.py
@@ -75,8 +75,7 @@ class NameCollisionTest(helpers.TestCase):
         </sdf>
         """
         root = sdf.Root()
-        errors = root.load_sdf_string(sdf_string)
-        self.assertEqual(0, len(errors))
+        root.load_sdf_string(sdf_string)
         mjcf_root = add_root(root)
         bodies = mjcf_root.find_all("body")
         self.assertEqual(3, len(bodies))
@@ -97,8 +96,7 @@ class NameCollisionTest(helpers.TestCase):
         </sdf>
         """
         root = sdf.Root()
-        errors = root.load_sdf_string(sdf_string)
-        self.assertEqual(0, len(errors))
+        root.load_sdf_string(sdf_string)
         mjcf_root = add_root(root)
         joints = mjcf_root.find_all("joint")
         self.assertEqual(3, len(joints))
@@ -147,8 +145,7 @@ class NameCollisionTest(helpers.TestCase):
         </sdf>
         """
         root = sdf.Root()
-        errors = root.load_sdf_string(sdf_string)
-        self.assertEqual(0, len(errors))
+        root.load_sdf_string(sdf_string)
         mjcf_root = add_root(root)
         joints = mjcf_root.find_all("joint")
         self.assertEqual(8, len(joints))

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_sdf_kinematics.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_sdf_kinematics.py
@@ -25,8 +25,7 @@ class TreeTest(unittest.TestCase):
 
     def load_sdf_file(self, file_name):
         root = sdf.Root()
-        errors = root.load(file_name)
-        self.assertEqual(0, len(errors), errors)
+        root.load(file_name)
         return root
 
     def test_hierarchy(self):


### PR DESCRIPTION
# 🎉 New feature

## Summary

After https://github.com/gazebosim/sdformat/pull/1061, any function in libsdformat that would return an `sdf::Errors` now throws an exception that wraps the errors. This PR makes the necessary API changes to accommodate that.

- Needs https://github.com/gazebosim/sdformat/pull/1061

## Test it
Existing tests should pass.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
