### PR TITLE
SDFormat->MJCF: Handle relative resource paths

### DIFF
--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/sdformat_to_mjcf.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/sdformat_to_mjcf.py
@@ -34,6 +34,13 @@ def sdformat_file_to_mjcf(input_file, output_file):
         print(e, file=sys.stderr)
         return 1
     else:
+        input_dir, _ = os.path.split(os.path.abspath(input_file))
+        # Change CWD to the input dir so that assets with relative file paths
+        # can be found. For example, when running the converter from a
+        # directory outside the input dir and the input file has
+        # `<albedo_map>materials/textures/foo.png</albedo_map>`
+        os.chdir(input_dir)
+
         mjcf_root = add_root(root)
         mjcf_root.default.dclass = "unused"
         output_dir, file_name = os.path.split(os.path.abspath(output_file))

--- a/sdformat_mjcf/tests/resources/box_obj/model.sdf
+++ b/sdformat_mjcf/tests/resources/box_obj/model.sdf
@@ -16,6 +16,13 @@
               <uri>meshes/box.obj</uri>
           </mesh>
         </geometry>
+        <material>
+          <pbr>
+            <metal>
+              <albedo_map>textures/albedo_map.png</albedo_map>
+            </metal>
+          </pbr>
+        </material>
       </visual>
     </link>
   </model>

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_cli.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_cli.py
@@ -76,6 +76,18 @@ class CLITest(unittest.TestCase):
             self.assertEqual(0, return_code)
             self.assertTrue(os.path.exists(output_file))
 
+    def test_relative_resource_path(self):
+        model_dir = TEST_RESOURCES_DIR / "box_obj"
+        model_file = model_dir / "model.sdf"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.chdir(temp_dir)
+            os.mkdir("mjcf")
+            self.assertNotEqual(os.getcwd(), str(model_dir))
+            output_file = path.join("mjcf", "box_obj.xml")
+            return_code = cli.main([str(model_file), output_file])
+            self.assertEqual(0, return_code)
+            self.assertTrue(os.path.exists(output_file))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

This fixes an exception thrown when an input SDFormat file has resources that use relative URIs and the converter is run from a directory where the relative path doesn't point to the desired file.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸