### PR TITLE
Use MJCF default values for gravity, magnetic, and wind when not set

### DIFF
--- a/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/world.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/mjcf_to_sdformat/converters/world.py
@@ -26,6 +26,10 @@ from sdformat_mjcf.utils.defaults import MjcfModifiers
 
 import sdformat as sdf
 
+MJCF_DEFAULT_GRAVITY = [0, 0, -9.81]
+MJCF_DEFAULT_MAGNETIC = [0, -0.5, 0]
+MJCF_DEFAULT_WIND = [0, 0, 0]
+
 
 def _is_floating_body(body):
     freejoint = body.get_children("freejoint")
@@ -137,15 +141,21 @@ def mjcf_worldbody_to_sdf(mjcf_root, physics, world,
     if mjcf_root.option is not None:
         if mjcf_root.option.flag.gravity == "disable":
             world.set_gravity(Vector3d(0, 0, 0))
-        elif mjcf_root.option.gravity is not None:
-            world.set_gravity(su.list_to_vec3d(mjcf_root.option.gravity))
-        if mjcf_root.option.magnetic is not None:
-            world.set_magnetic_field(
-                su.list_to_vec3d(mjcf_root.option.magnetic))
-        if mjcf_root.option.wind is not None:
-            world.set_wind_linear_velocity(
-                su.list_to_vec3d(mjcf_root.option.wind))
+        else:
+            world.set_gravity(
+                su.list_to_vec3d(
+                    su.get_value_or_default(mjcf_root.option.gravity,
+                                            MJCF_DEFAULT_GRAVITY)))
 
+        world.set_magnetic_field(
+            su.list_to_vec3d(
+                su.get_value_or_default(mjcf_root.option.magnetic,
+                                        MJCF_DEFAULT_MAGNETIC)))
+
+        world.set_wind_linear_velocity(
+            su.list_to_vec3d(
+                su.get_value_or_default(mjcf_root.option.wind,
+                                        MJCF_DEFAULT_WIND)))
     models = []
     root_body_to_model = {}
     for body in mjcf_root.worldbody.body:

--- a/sdformat_mjcf/tests/mjcf_to_sdformat/test_add_mjcf_worldbody_to_sdf.py
+++ b/sdformat_mjcf/tests/mjcf_to_sdformat/test_add_mjcf_worldbody_to_sdf.py
@@ -25,6 +25,9 @@ import sdformat as sdf
 
 from sdformat_mjcf.mjcf_to_sdformat.converters.world import (
     mjcf_worldbody_to_sdf,
+    MJCF_DEFAULT_GRAVITY,
+    MJCF_DEFAULT_MAGNETIC,
+    MJCF_DEFAULT_WIND,
 )
 import sdformat_mjcf.utils.sdf_utils as su
 
@@ -323,6 +326,22 @@ class ModelTest(unittest.TestCase):
         link = model.link_by_index(0)
         self.assertEqual(2, link.visual_count())
         self.assertEqual(2, link.collision_count())
+
+    def test_unset_gravity_magnetic_wind(self):
+        filename = str(TEST_RESOURCES_DIR / "test_unnamed_geoms.xml")
+        mjcf_model = mjcf.from_path(filename)
+        physics = mujoco.Physics.from_xml_path(filename)
+
+        world = sdf.World()
+        world.set_name("default")
+
+        mjcf_worldbody_to_sdf(mjcf_model, physics, world)
+        self.assertEqual(Vector3d(*MJCF_DEFAULT_MAGNETIC),
+                         world.magnetic_field())
+        self.assertEqual(Vector3d(*MJCF_DEFAULT_GRAVITY),
+                         world.gravity())
+        self.assertEqual(Vector3d(*MJCF_DEFAULT_WIND),
+                         world.wind_linear_velocity())
 
 
 class PoseTest(unittest.TestCase):


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
We weren't using the correct MJCF default values for `gravity`, `magnetic`, and `wind`. The default for `wind` matches the SDFormat default so it wasn't an issue, but the other elements, especially, `magnetic`, had different values. 
 
## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
