### PR TITLE
SDFormat -> MJCF: Set mesh scale

### DIFF
--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/geometry.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/geometry.py
@@ -92,6 +92,7 @@ def add_geometry(body, name, pose, sdf_geom):
                                             file=mesh_file_path)
         else:
             geom.mesh = asset_loaded
+        geom.mesh.scale = su.vec3d_to_list(mesh_shape.scale())
     else:
         raise RuntimeError(
             f"Encountered unsupported shape type {sdf_geom.type()}")

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_geometry.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_geometry.py
@@ -123,6 +123,7 @@ class GeometryTest(helpers.TestCase):
         mesh.set_uri("meshes/box.obj")
         mesh.set_file_path(
             os.path.join(get_resources_dir(), "box_obj", "model.sdf"))
+        mesh.set_scale(Vector3d(0.1, 0.2, 0.3))
 
         geometry = sdf.Geometry()
         geometry.set_mesh_shape(mesh)
@@ -135,6 +136,8 @@ class GeometryTest(helpers.TestCase):
         self.assertEqual("mesh_shape", mj_geom.name)
         self.assertEqual("mesh", mj_geom.type)
         self.assertEqual(1, len(mujoco.asset.find_all('mesh')))
+        mj_mesh = mujoco.asset.mesh[0]
+        assert_allclose([0.1, 0.2, 0.3], mj_mesh.scale)
 
     def test_plane(self):
         plane = sdf.Plane()


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The mesh scale was not being set when converting from SDFormat to MJCF.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
