### PR TITLE
Add dependency on dm-control

### DIFF
--- a/sdformat_mjcf/README.md
+++ b/sdformat_mjcf/README.md
@@ -8,15 +8,13 @@ approximately equivalent results; and vice versa.
 
 ## Install sdformat-mjcf
 
-To start development, create a python3 virtual environment, upgrade pip and
-install dm-control
+To start development, create a python3 virtual environment, and upgrade pip.
 
 ```bash
 python3 -m venv path/to/venv --system-site-packages
 . path/to/venv/bin/activate
 
 pip install -U pip
-pip install dm-control
 ```
 
 Install `python3-gz-math7` and `python3-sdformat13` from the

--- a/sdformat_mjcf/setup.py
+++ b/sdformat_mjcf/setup.py
@@ -42,4 +42,7 @@ setup(
             'mjcf2sdf= sdformat_mjcf.mjcf_to_sdformat.cli:main',
         ],
     },
+    install_requires=[
+        'dm-control',
+    ],
 )


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This allows us to do `pip install sdformat-mjcf` and have `dm-control` automatically installed.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
