### PR TITLE
Use quaternions instead of euler angles in MJCF output to avoid eulerseq global pollution.

### DIFF
--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/cli.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/cli.py
@@ -30,9 +30,13 @@ def main(argv=None):
                         help="Path to input SDFormat file (World or Model)")
     parser.add_argument("output_file",
                         help="Desired path for the output MJCF file")
+    parser.add_argument("--euler_xyz", action="store_true",
+                        help="Use Euler XYZ angles instead of quaternions and "
+                             "set compiler eulerseq to XYZ")
 
     args = parser.parse_args(argv)
-    return sdformat_file_to_mjcf(args.input_file, args.output_file)
+    return sdformat_file_to_mjcf(args.input_file, args.output_file,
+                                 euler_xyz=args.euler_xyz)
 
 
 if __name__ == "__main__":

--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/geometry.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/geometry.py
@@ -42,7 +42,7 @@ def add_geometry(body, name, pose, sdf_geom):
         "geom",
         name=su.find_unique_name(body, "geom", name),
         pos=su.vec3d_to_list(pose.pos()),
-        euler=su.quat_to_euler_list(pose.rot()),
+        quat=su.quat_to_list(pose.rot()),
     )
 
     if sdf_geom.box_shape():

--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/geometry.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/geometry.py
@@ -38,9 +38,7 @@ def add_geometry(body, name, pose, sdf_geom):
 
     if sdf_geom is None:
         return
-    use_euler = body.root.compiler.eulerseq == 'XYZ'
-    rot_kwargs = ({"euler": su.quat_to_euler_list(pose.rot())}
-                 if use_euler else {"quat": su.quat_to_list(pose.rot())})
+    rot_kwargs = su.get_rotation_kwargs(body, pose.rot())
     geom = body.add(
         "geom",
         name=su.find_unique_name(body, "geom", name),

--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/geometry.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/geometry.py
@@ -38,11 +38,14 @@ def add_geometry(body, name, pose, sdf_geom):
 
     if sdf_geom is None:
         return
+    use_euler = body.root.compiler.eulerseq == 'XYZ'
+    rot_kwargs = ({"euler": su.quat_to_euler_list(pose.rot())}
+                 if use_euler else {"quat": su.quat_to_list(pose.rot())})
     geom = body.add(
         "geom",
         name=su.find_unique_name(body, "geom", name),
         pos=su.vec3d_to_list(pose.pos()),
-        quat=su.quat_to_list(pose.rot()),
+        **rot_kwargs,
     )
 
     if sdf_geom.box_shape():

--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/link.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/link.py
@@ -60,7 +60,7 @@ def add_link(body, link, parent_name="world", link_pose=None, link_name=None):
     body = body.add("body",
                     name=su.find_unique_name(body, "body", link_name),
                     pos=su.vec3d_to_list(pose.pos()),
-                    euler=su.quat_to_euler_list(pose.rot()))
+                    quat=su.quat_to_list(pose.rot()))
 
     # SDFormat allows specifying diagonal and off-diagonal terms of the inertia
     # matrix in addition to setting the orientation of the inertia frame.

--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/link.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/link.py
@@ -57,9 +57,7 @@ def add_link(body, link, parent_name="world", link_pose=None, link_name=None):
             pose = su.graph_resolver.resolve_pose(sem_pose, parent_name)
 
     link_name = link_name if link_name else link.name()
-    use_euler = body.root.compiler.eulerseq == 'XYZ'
-    rot_kwargs = ({"euler": su.quat_to_euler_list(pose.rot())}
-                 if use_euler else {"quat": su.quat_to_list(pose.rot())})
+    rot_kwargs = su.get_rotation_kwargs(body, pose.rot())
     body = body.add("body",
                     name=su.find_unique_name(body, "body", link_name),
                     pos=su.vec3d_to_list(pose.pos()),

--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/link.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/link.py
@@ -57,10 +57,13 @@ def add_link(body, link, parent_name="world", link_pose=None, link_name=None):
             pose = su.graph_resolver.resolve_pose(sem_pose, parent_name)
 
     link_name = link_name if link_name else link.name()
+    use_euler = body.root.compiler.eulerseq == 'XYZ'
+    rot_kwargs = ({"euler": su.quat_to_euler_list(pose.rot())}
+                 if use_euler else {"quat": su.quat_to_list(pose.rot())})
     body = body.add("body",
                     name=su.find_unique_name(body, "body", link_name),
                     pos=su.vec3d_to_list(pose.pos()),
-                    quat=su.quat_to_list(pose.rot()))
+                    **rot_kwargs)
 
     # SDFormat allows specifying diagonal and off-diagonal terms of the inertia
     # matrix in addition to setting the orientation of the inertia frame.

--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/root.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/root.py
@@ -27,7 +27,6 @@ def add_root(root):
     :rtype: mjcf.RootElement
     """
     mjcf_root = mjcf.RootElement()
-    mjcf_root.compiler.eulerseq = 'XYZ'
     if root.model():
         mjcf_root.model = root.model().name()
     elif root.world_count() == 1:

--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/root.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/root.py
@@ -18,15 +18,19 @@ from sdformat_mjcf.sdformat_to_mjcf.converters.model import add_model
 from sdformat_mjcf.sdformat_to_mjcf.converters.world import add_world
 
 
-def add_root(root):
+def add_root(root, euler_xyz=False):
     """
     Converts an SDFormat Root object to MJCF.
 
     :param sdformat.Root root: The SDFormat root to be converted.
+    :param bool euler_xyz: If True, set compiler eulerseq to 'XYZ' and use
+    Euler angles instead of quaternions for rotations.
     :return: The newly created MJCF root element.
     :rtype: mjcf.RootElement
     """
     mjcf_root = mjcf.RootElement()
+    if euler_xyz:
+        mjcf_root.compiler.eulerseq = 'XYZ'
     if root.model():
         mjcf_root.model = root.model().name()
     elif root.world_count() == 1:

--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/sensor.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/sensor.py
@@ -45,7 +45,7 @@ def add_sensor(body, sensor):
         body.add("site",
                  name=site_unique_name,
                  pos=su.vec3d_to_list(pose.pos()),
-                 euler=su.quat_to_euler_list(pose.rot()))
+                 quat=su.quat_to_list(pose.rot()))
 
         if sensor.imu_sensor() is not None:
             return _add_imu(body.root.sensor,
@@ -216,5 +216,5 @@ def _add_camera_sensor(body, camera_sensor, sensor_name, sensor_pose):
     mj_camera = body.add("camera",
                          name=camera_name,
                          pos=su.vec3d_to_list(sensor_pose.pos()),
-                         euler=su.quat_to_euler_list(sensor_pose.rot()))
+                         quat=su.quat_to_list(sensor_pose.rot()))
     return mj_camera

--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/sensor.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/sensor.py
@@ -42,9 +42,7 @@ def add_sensor(body, sensor):
         # Creates a site inside the body with the same name as sensor. This
         # site will be used to attach the actual sensor to the body.
         site_unique_name = su.find_unique_name(body, "site", sensor.name())
-        use_euler = body.root.compiler.eulerseq == 'XYZ'
-        rot_kwargs = ({"euler": su.quat_to_euler_list(pose.rot())}
-                     if use_euler else {"quat": su.quat_to_list(pose.rot())})
+        rot_kwargs = su.get_rotation_kwargs(body, pose.rot())
         body.add("site",
                  name=site_unique_name,
                  pos=su.vec3d_to_list(pose.pos()),
@@ -216,9 +214,7 @@ def _add_camera_sensor(body, camera_sensor, sensor_name, sensor_pose):
         "Converting an SDFormat Camera sensor. Beware that the conversion is "
         "very rudimentary and most SDFormat parameters are not mapped to MJCF."
     )
-    use_euler = body.root.compiler.eulerseq == 'XYZ'
-    rot_kwargs = ({"euler": su.quat_to_euler_list(sensor_pose.rot())}
-                 if use_euler else {"quat": su.quat_to_list(sensor_pose.rot())})
+    rot_kwargs = su.get_rotation_kwargs(body, sensor_pose.rot())
     mj_camera = body.add("camera",
                          name=camera_name,
                          pos=su.vec3d_to_list(sensor_pose.pos()),

--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/sensor.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/converters/sensor.py
@@ -42,10 +42,13 @@ def add_sensor(body, sensor):
         # Creates a site inside the body with the same name as sensor. This
         # site will be used to attach the actual sensor to the body.
         site_unique_name = su.find_unique_name(body, "site", sensor.name())
+        use_euler = body.root.compiler.eulerseq == 'XYZ'
+        rot_kwargs = ({"euler": su.quat_to_euler_list(pose.rot())}
+                     if use_euler else {"quat": su.quat_to_list(pose.rot())})
         body.add("site",
                  name=site_unique_name,
                  pos=su.vec3d_to_list(pose.pos()),
-                 quat=su.quat_to_list(pose.rot()))
+                 **rot_kwargs)
 
         if sensor.imu_sensor() is not None:
             return _add_imu(body.root.sensor,
@@ -213,8 +216,11 @@ def _add_camera_sensor(body, camera_sensor, sensor_name, sensor_pose):
         "Converting an SDFormat Camera sensor. Beware that the conversion is "
         "very rudimentary and most SDFormat parameters are not mapped to MJCF."
     )
+    use_euler = body.root.compiler.eulerseq == 'XYZ'
+    rot_kwargs = ({"euler": su.quat_to_euler_list(sensor_pose.rot())}
+                 if use_euler else {"quat": su.quat_to_list(sensor_pose.rot())})
     mj_camera = body.add("camera",
                          name=camera_name,
                          pos=su.vec3d_to_list(sensor_pose.pos()),
-                         quat=su.quat_to_list(sensor_pose.rot()))
+                         **rot_kwargs)
     return mj_camera

--- a/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/sdformat_to_mjcf.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/sdformat_to_mjcf/sdformat_to_mjcf.py
@@ -20,12 +20,14 @@ from dm_control.mjcf.export_with_assets import export_with_assets
 from sdformat_mjcf.sdformat_to_mjcf.converters.root import add_root
 
 
-def sdformat_file_to_mjcf(input_file, output_file):
+def sdformat_file_to_mjcf(input_file, output_file, euler_xyz=False):
     """
     Loads an SDFormat input file and converts to MJCF.
     :param str input_file: Path to input SDFormat Model or World file
     :param str output_file: Path to output MJCF file. Any generated artifacts,
     such as meshes will be output to the directory containing the output file.
+    :param bool euler_xyz: If True, use Euler XYZ angles instead of quaternions
+    and set the MJCF compiler eulerseq to 'XYZ'.
     """
     root = sdf.Root()
     try:
@@ -43,7 +45,7 @@ def sdformat_file_to_mjcf(input_file, output_file):
         previous_cwd = os.getcwd()
         try:
             os.chdir(input_dir)
-            mjcf_root = add_root(root)
+            mjcf_root = add_root(root, euler_xyz=euler_xyz)
             mjcf_root.default.dclass = "unused"
             export_with_assets(mjcf_root, output_dir, file_name)
         finally:

--- a/sdformat_mjcf/src/sdformat_mjcf/utils/sdf_utils.py
+++ b/sdformat_mjcf/src/sdformat_mjcf/utils/sdf_utils.py
@@ -131,6 +131,41 @@ def quat_to_euler_list(quat):
     return [math.degrees(val) for val in vec3d_to_list(quat.euler())]
 
 
+def get_rotation_kwargs(element, quat):
+    """
+    Build the kwargs used to set the rotation attribute of an MJCF element
+    from a quaternion. Uses ``euler`` when ``element.root.compiler.eulerseq``
+    is ``'XYZ'``, otherwise uses ``quat``.
+
+    :param mjcf.Element element: An MJCF element whose ``root.compiler.eulerseq``
+        is consulted to decide which attribute to emit.
+    :param gz.math.Quaterniond quat: Rotation to encode.
+    :return: A dict containing either ``{'euler': list[float]}`` or
+        ``{'quat': list[float]}`` ready to be splatted into ``mjcf.Element.add``.
+    :rtype: dict
+    """
+    if element.root.compiler.eulerseq == 'XYZ':
+        return {"euler": quat_to_euler_list(quat)}
+    return {"quat": quat_to_list(quat)}
+
+
+def euler_list_to_quat_wxyz(euler_list):
+    """
+    Convert a list of Euler angles in degrees to a wxyz quaternion list.
+
+    This is the inverse of :func:`quat_to_euler_list` and round-trips through
+    :class:`gz.math.Pose3d` so it produces the same quat the converter would
+    emit via :func:`get_rotation_kwargs` for the same input rotation.
+
+    :param list[float] euler_list: ``[roll, pitch, yaw]`` in degrees.
+    :return: Quaternion components in ``wxyz`` order.
+    :rtype: list[float]
+    """
+    rad = [math.radians(v) for v in euler_list]
+    pose = Pose3d(0.0, 0.0, 0.0, rad[0], rad[1], rad[2])
+    return quat_to_list(pose.rot())
+
+
 def wxyz_list_to_quat(quat):
     """
     Convert a Quaternion list defined as wxyz to a gz.math.Quateriond.

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_geometry.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_geometry.py
@@ -50,7 +50,8 @@ class GeometryTest(helpers.TestCase):
         self.assertEqual("box", mj_geom.type)
         assert_allclose([x_size / 2., y_size / 2., z_size / 2.], mj_geom.size)
         assert_allclose(self.expected_pos, mj_geom.pos)
-        assert_allclose(self.expected_euler, mj_geom.euler)
+        self.assertIsNone(mj_geom.euler)
+        self.assertIsNotNone(mj_geom.quat)
 
     def test_capsule(self):
         capsule = sdf.Capsule()
@@ -71,7 +72,8 @@ class GeometryTest(helpers.TestCase):
         self.assertEqual("capsule", mj_geom.type)
         assert_allclose([radius, length / 2.], mj_geom.size)
         assert_allclose(self.expected_pos, mj_geom.pos)
-        assert_allclose(self.expected_euler, mj_geom.euler)
+        self.assertIsNone(mj_geom.euler)
+        self.assertIsNotNone(mj_geom.quat)
 
     def test_cylinder(self):
         cylinder = sdf.Cylinder()
@@ -92,7 +94,8 @@ class GeometryTest(helpers.TestCase):
         self.assertEqual("cylinder", mj_geom.type)
         assert_allclose([radius, length / 2.], mj_geom.size)
         assert_allclose(self.expected_pos, mj_geom.pos)
-        assert_allclose(self.expected_euler, mj_geom.euler)
+        self.assertIsNone(mj_geom.euler)
+        self.assertIsNotNone(mj_geom.quat)
 
     def test_ellipsoid(self):
         ellipsoid = sdf.Ellipsoid()
@@ -113,7 +116,8 @@ class GeometryTest(helpers.TestCase):
         self.assertEqual("ellipsoid", mj_geom.type)
         assert_allclose([x_radius, y_radius, z_radius], mj_geom.size)
         assert_allclose(self.expected_pos, mj_geom.pos)
-        assert_allclose(self.expected_euler, mj_geom.euler)
+        self.assertIsNone(mj_geom.euler)
+        self.assertIsNotNone(mj_geom.quat)
 
     def test_heightmap(self):
         pass
@@ -160,7 +164,8 @@ class GeometryTest(helpers.TestCase):
         self.assertEqual("plane", mj_geom.type)
         assert_allclose([x_size / 2., y_size / 2., 1.], mj_geom.size)
         assert_allclose(self.expected_pos, mj_geom.pos)
-        assert_allclose(self.expected_euler, mj_geom.euler)
+        self.assertIsNone(mj_geom.euler)
+        self.assertIsNotNone(mj_geom.quat)
 
     def test_sphere(self):
         sphere = sdf.Sphere()
@@ -179,7 +184,25 @@ class GeometryTest(helpers.TestCase):
         self.assertEqual("sphere", mj_geom.type)
         assert_allclose(radius, mj_geom.size)
         assert_allclose(self.expected_pos, mj_geom.pos)
+        self.assertIsNone(mj_geom.euler)
+        self.assertIsNotNone(mj_geom.quat)
+
+    def test_geom_euler_xyz(self):
+        """Geom uses euler angles when compiler eulerseq is XYZ."""
+        box = sdf.Box()
+        box.set_size(Vector3d(1, 2, 3))
+        geometry = sdf.Geometry()
+        geometry.set_box_shape(box)
+        geometry.set_type(sdf.GeometryType.BOX)
+
+        mujoco = mjcf.RootElement(model="test")
+        mujoco.compiler.eulerseq = 'XYZ'
+        body = mujoco.worldbody.add('body')
+        mj_geom = geometry_conv.add_geometry(body, "box_shape", self.test_pose,
+                                             geometry)
+        assert_allclose(self.expected_pos, mj_geom.pos)
         assert_allclose(self.expected_euler, mj_geom.euler)
+        self.assertIsNone(mj_geom.quat)
 
 
 class SurfaceTest(helpers.TestCase):
@@ -221,7 +244,8 @@ class CollisionTest(helpers.TestCase):
         mj_geom = geometry_conv.add_collision(body, collision)
         self.assertEqual("c1", mj_geom.name)
         assert_allclose([1., 2., 3.], mj_geom.pos)
-        assert_allclose([90., 60., 45.], mj_geom.euler)
+        self.assertIsNone(mj_geom.euler)
+        self.assertIsNotNone(mj_geom.quat)
         self.assertEqual(geometry_conv.COLLISION_GEOM_GROUP, mj_geom.group)
         self.assertIsNone(mj_geom.contype)
         self.assertIsNone(mj_geom.conaffinity)
@@ -245,7 +269,8 @@ class VisualTest(helpers.TestCase):
         mj_geom = geometry_conv.add_visual(body, visual)
         self.assertEqual("v1", mj_geom.name)
         assert_allclose([1., 2., 3.], mj_geom.pos)
-        assert_allclose([90., 60., 45.], mj_geom.euler)
+        self.assertIsNone(mj_geom.euler)
+        self.assertIsNotNone(mj_geom.quat)
         self.assertEqual(geometry_conv.VISUAL_GEOM_GROUP, mj_geom.group)
         self.assertEqual(0, mj_geom.contype)
         self.assertEqual(0, mj_geom.conaffinity)

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_joint.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_joint.py
@@ -303,7 +303,19 @@ class JointTest(helpers.TestCase):
             sensor_sites = child_body.get_children("site")
             self.assertEqual(1, len(sensor_sites))
             assert_allclose(frame_pos, sensor_sites[0].pos)
-            assert_allclose(frame_euler, sensor_sites[0].euler)
+            # add_sensor emits `quat` (not `euler`) by default, but
+            # add_joint overrides the site with `euler` for PARENT/CHILD
+            # frames. Check the attribute that the chosen frame path sets.
+            if frame == FTF.SENSOR:
+                self.assertIsNone(sensor_sites[0].euler)
+                expected_quat = su.euler_list_to_quat_wxyz(
+                    np.asarray(frame_euler, dtype=float).tolist())
+                assert_allclose(expected_quat, sensor_sites[0].quat)
+            else:
+                # For PARENT/CHILD, add_joint writes `euler` after the fact;
+                # dm_control retains the previously-set `quat` even though
+                # both attributes now describe the same rotation.
+                assert_allclose(frame_euler, sensor_sites[0].euler)
 
 
 if __name__ == "__main__":

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_link.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_link.py
@@ -60,7 +60,8 @@ class LinkTest(helpers.TestCase):
         mj_body = add_link(self.body, link)
         self.assertIsNotNone(mj_body)
         assert_allclose(self.expected_pos, mj_body.pos)
-        assert_allclose(self.expected_euler, mj_body.euler)
+        self.assertIsNone(mj_body.euler)
+        self.assertIsNotNone(mj_body.quat)
 
     def test_link_inertia(self):
         # This following is equivalent to
@@ -101,7 +102,8 @@ class LinkTest(helpers.TestCase):
 
         self.assertIsNotNone(mj_body2)
         assert_allclose(self.expected_pos, mj_body2.pos)
-        assert_allclose(self.expected_euler, mj_body2.euler)
+        self.assertIsNone(mj_body2.euler)
+        self.assertIsNotNone(mj_body2.quat)
 
     def test_link_with_geometry(self):
         link = sdf.Link()
@@ -132,7 +134,8 @@ class LinkTest(helpers.TestCase):
         mj_body = add_link(self.body, link)
         self.assertIsNotNone(mj_body)
         assert_allclose(self.expected_pos, mj_body.pos)
-        assert_allclose(self.expected_euler, mj_body.euler)
+        self.assertIsNone(mj_body.euler)
+        self.assertIsNotNone(mj_body.quat)
         geoms = mj_body.find_all('geom')
         self.assertEqual(2, len(geoms))
         self.assertEqual("c1", geoms[0].name)
@@ -201,6 +204,18 @@ class LinkTest(helpers.TestCase):
         self.assertIsNotNone(mj_body)
         self.assertEqual(1, len(mj_body.get_children("camera")))
 
+    def test_link_euler_xyz(self):
+        """Link body uses euler angles when compiler eulerseq is XYZ."""
+        self.mujoco.compiler.eulerseq = 'XYZ'
+        link = sdf.Link()
+        link.set_name("euler_link")
+        link.set_raw_pose(self.test_pose)
+        mj_body = add_link(self.body, link)
+
+        assert_allclose(self.expected_pos, mj_body.pos)
+        assert_allclose(self.expected_euler, mj_body.euler)
+        self.assertIsNone(mj_body.quat)
+
 
 class LinkIntegration(unittest.TestCase):
     expected_pos = [1.0, 2.0, 3.0]
@@ -219,7 +234,7 @@ class LinkIntegration(unittest.TestCase):
 
         root = sdf.Root()
         root.load_sdf_string(model_string)
-        mjcf_root = add_root(root)
+        mjcf_root = add_root(root, euler_xyz=True)
         mj_link = mjcf_root.find("body", "L1")
         assert_allclose(self.expected_pos, mj_link.pos)
         assert_allclose(self.expected_euler, mj_link.euler)

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_model.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_model.py
@@ -78,18 +78,18 @@ class ModelTest(helpers.TestCase):
         self.assertIsNotNone(mj_float_link_2)
 
         float_link_1_expected_pos = su.vec3d_to_list(model_raw_pose.pos())
-        float_link_1_expected_euler = su.quat_to_euler_list(
+        float_link_1_expected_quat = su.quat_to_list(
             model_raw_pose.rot())
         assert_allclose(float_link_1_expected_pos, mj_float_link_1.pos)
-        assert_allclose(float_link_1_expected_euler, mj_float_link_1.euler)
+        assert_allclose(float_link_1_expected_quat, mj_float_link_1.quat)
 
         float_link_2_expected_pose = model_raw_pose * float_link_2_raw_pose
         float_link_2_expected_pos = su.vec3d_to_list(
             float_link_2_expected_pose.pos())
-        float_link_2_expected_euler = su.quat_to_euler_list(
+        float_link_2_expected_quat = su.quat_to_list(
             float_link_2_expected_pose.rot())
         assert_allclose(float_link_2_expected_pos, mj_float_link_2.pos)
-        assert_allclose(float_link_2_expected_euler, mj_float_link_2.euler)
+        assert_allclose(float_link_2_expected_quat, mj_float_link_2.quat)
 
     def test_model_multiple_links_with_joint(self):
         model_raw_pose = self.test_pose
@@ -124,9 +124,9 @@ class ModelTest(helpers.TestCase):
         self.assertIsNotNone(mj_upper_link)
 
         base_link_expected_pos = su.vec3d_to_list(model_raw_pose.pos())
-        base_link_expected_euler = su.quat_to_euler_list(model_raw_pose.rot())
+        base_link_expected_quat = su.quat_to_list(model_raw_pose.rot())
         assert_allclose(base_link_expected_pos, mj_base_link.pos)
-        assert_allclose(base_link_expected_euler, mj_base_link.euler)
+        assert_allclose(base_link_expected_quat, mj_base_link.quat)
 
         # upper_link has a pose `upper_link_raw_pose` relative to the model
         # frame. If it a floating body under worldbody, it's pose would be:
@@ -135,10 +135,10 @@ class ModelTest(helpers.TestCase):
         # `upper_link` relative to `base_link` is just `upper_link_raw_pose`.
         # i.e., `model_raw_pose` does not affect the poser of upper_link
         upper_link_expected_pos = su.vec3d_to_list(upper_link_raw_pose.pos())
-        upper_link_expected_euler = su.quat_to_euler_list(
+        upper_link_expected_quat = su.quat_to_list(
             upper_link_raw_pose.rot())
         assert_allclose(upper_link_expected_pos, mj_upper_link.pos)
-        assert_allclose(upper_link_expected_euler, mj_upper_link.euler)
+        assert_allclose(upper_link_expected_quat, mj_upper_link.quat)
 
     def test_collision_exclusions(self):
         test_model_sdf = """

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_model.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_model.py
@@ -30,6 +30,9 @@ class ModelTest(helpers.TestCase):
     test_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)
     expected_pos = [1.0, 2.0, 3.0]
     expected_euler = [90.0, 60.0, 45.0]
+    # The converter emits `quat` (not `euler`) by default, so the test
+    # checks the equivalent wxyz quaternion.
+    expected_quat = su.euler_list_to_quat_wxyz(expected_euler)
 
     def setUp(self):
         self.mujoco = mjcf.RootElement(model="test")
@@ -50,7 +53,8 @@ class ModelTest(helpers.TestCase):
         self.assertEqual("base_link", mj_bodies[0].name)
 
         assert_allclose(self.expected_pos, mj_bodies[0].pos)
-        assert_allclose(self.expected_euler, mj_bodies[0].euler)
+        self.assertIsNone(mj_bodies[0].euler)
+        assert_allclose(self.expected_quat, mj_bodies[0].quat)
 
     def test_model_multiple_floating_links(self):
         model_raw_pose = self.test_pose
@@ -348,21 +352,31 @@ class ModelIntegrationTest(unittest.TestCase):
         mj_root = add_root(root)
         self.assertIsNotNone(mj_root)
 
-        # Copied from arm.urdf
+        # Copied from arm.urdf. The converter emits `quat` (not `euler`) by
+        # default, so we compare against the equivalent wxyz quaternion.
         expected_poses = {
-            'link_1': {'pos': [0, 0, 0.1], 'euler': [0.0, 0, 0]},
-            'link_2': {'pos': [0, 0, 0.2], 'euler': [0.0, 0, 0]},
-            'link_3': {'pos': [0, 0, 0.4], 'euler': [0.0, 90.0, 0]},
-            'link_4': {'pos': [0, 0, 0.35], 'euler': [0.0, 0.0, 0]},
-            'link_5': {'pos': [0, 0, 0.06], 'euler': [0.0, 0.0, 0]},
-            'link_6': {'pos': [0, 0, 0.08], 'euler': [0.0, 0.0, 0]},
+            'link_1': {'pos': [0, 0, 0.1],
+                       'quat': su.euler_list_to_quat_wxyz([0.0, 0, 0])},
+            'link_2': {'pos': [0, 0, 0.2],
+                       'quat': su.euler_list_to_quat_wxyz([0.0, 0, 0])},
+            'link_3': {'pos': [0, 0, 0.4],
+                       'quat': su.euler_list_to_quat_wxyz([0.0, 90.0, 0])},
+            'link_4': {'pos': [0, 0, 0.35],
+                       'quat': su.euler_list_to_quat_wxyz([0.0, 0.0, 0])},
+            'link_5': {'pos': [0, 0, 0.06],
+                       'quat': su.euler_list_to_quat_wxyz([0.0, 0.0, 0])},
+            'link_6': {'pos': [0, 0, 0.08],
+                       'quat': su.euler_list_to_quat_wxyz([0.0, 0.0, 0])},
         }
         for link, expectations in expected_poses.items():
             mj_body = mj_root.find("body", link)
-            pos = getattr(mj_body, "pos", [0.0, 0, 0])
-            euler = getattr(mj_body, "euler", [0.0, 0, 0])
+            # `pos` may not be set on bodies with identity position; in that
+            # case dm_control returns None rather than omitting the attribute.
+            pos = mj_body.pos if mj_body.pos is not None else [0.0, 0, 0]
             assert_allclose(pos, expectations['pos'], atol=1e-10)
-            assert_allclose(euler, expectations['euler'], atol=0.2)
+            # The converter always emits `quat` (not `euler`) unless
+            # compiler.eulerseq is 'XYZ'.
+            assert_allclose(mj_body.quat, expectations['quat'], atol=0.2)
 
 
 if __name__ == "__main__":

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_sensor.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_sensor.py
@@ -29,6 +29,15 @@ class Altimeter(helpers.TestCase):
     test_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)
     expected_pos = [1.0, 2.0, 3.0]
     expected_euler = [90.0, 60.0, 45.0]
+    # Expected quaternion (wxyz) corresponding to roll=pi/2, pitch=pi/3,
+    # yaw=pi/4. Matches the wxyz order used by MJCF `<site>`/`quat` and
+    # by `sdformat_mjcf.utils.sdf_utils.quat_to_list`.
+    expected_quat = [
+        0.701057384649978,
+        0.4304593345768794,
+        0.560985526796931,
+        -0.09229595564125716,
+    ]
 
     def setUp(self):
         self.mujoco = mjcf.RootElement(model="test")
@@ -54,7 +63,7 @@ class Altimeter(helpers.TestCase):
         self.assertEqual(self.sensor.name(), sensor_sites[0].name)
         assert_allclose(self.expected_pos, sensor_sites[0].pos)
         self.assertIsNone(sensor_sites[0].euler)
-        self.assertIsNotNone(sensor_sites[0].quat)
+        assert_allclose(self.expected_quat, sensor_sites[0].quat)
 
         mjcf_altimeter = mjcf_sensors
         self.assertAlmostEqual(f"altimeter_{self.sensor.name()}",
@@ -78,6 +87,15 @@ class ImuSensorTest(helpers.TestCase):
     test_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)
     expected_pos = [1.0, 2.0, 3.0]
     expected_euler = [90.0, 60.0, 45.0]
+    # Expected quaternion (wxyz) corresponding to roll=pi/2, pitch=pi/3,
+    # yaw=pi/4. Matches the wxyz order used by MJCF `<site>`/`quat` and
+    # by `sdformat_mjcf.utils.sdf_utils.quat_to_list`.
+    expected_quat = [
+        0.701057384649978,
+        0.4304593345768794,
+        0.560985526796931,
+        -0.09229595564125716,
+    ]
 
     def setUp(self):
         self.mujoco = mjcf.RootElement(model="test")
@@ -106,7 +124,7 @@ class ImuSensorTest(helpers.TestCase):
         self.assertEqual(self.sensor.name(), sensor_sites[0].name)
         assert_allclose(self.expected_pos, sensor_sites[0].pos)
         self.assertIsNone(sensor_sites[0].euler)
-        self.assertIsNotNone(sensor_sites[0].quat)
+        assert_allclose(self.expected_quat, sensor_sites[0].quat)
 
         mjcf_accel, mjcf_gyro = mjcf_sensors
         self.assertAlmostEqual(f"accelerometer_{self.sensor.name()}",
@@ -150,7 +168,7 @@ class ImuSensorTest(helpers.TestCase):
         self.assertEqual(self.sensor.name(), sensor_sites[0].name)
         assert_allclose(self.expected_pos, sensor_sites[0].pos)
         self.assertIsNone(sensor_sites[0].euler)
-        self.assertIsNotNone(sensor_sites[0].quat)
+        assert_allclose(self.expected_quat, sensor_sites[0].quat)
 
         mjcf_accel, mjcf_gyro = mjcf_sensors
         self.assertAlmostEqual(f"accelerometer_{self.sensor.name()}",
@@ -208,6 +226,15 @@ class ForceTorqueSensorTest(helpers.TestCase):
     test_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)
     expected_pos = [1.0, 2.0, 3.0]
     expected_euler = [90.0, 60.0, 45.0]
+    # Expected quaternion (wxyz) corresponding to roll=pi/2, pitch=pi/3,
+    # yaw=pi/4. Matches the wxyz order used by MJCF `<site>`/`quat` and
+    # by `sdformat_mjcf.utils.sdf_utils.quat_to_list`.
+    expected_quat = [
+        0.701057384649978,
+        0.4304593345768794,
+        0.560985526796931,
+        -0.09229595564125716,
+    ]
 
     def setUp(self):
         self.mujoco = mjcf.RootElement(model="test")
@@ -236,7 +263,7 @@ class ForceTorqueSensorTest(helpers.TestCase):
         self.assertEqual(self.sensor.name(), sensor_sites[0].name)
         assert_allclose(self.expected_pos, sensor_sites[0].pos)
         self.assertIsNone(sensor_sites[0].euler)
-        self.assertIsNotNone(sensor_sites[0].quat)
+        assert_allclose(self.expected_quat, sensor_sites[0].quat)
 
         mjcf_force_sensor, mjcf_torque_sensor = mjcf_sensors
         self.assertAlmostEqual(f"force_{self.sensor.name()}",
@@ -281,7 +308,7 @@ class ForceTorqueSensorTest(helpers.TestCase):
         self.assertEqual(self.sensor.name(), sensor_sites[0].name)
         assert_allclose(self.expected_pos, sensor_sites[0].pos)
         self.assertIsNone(sensor_sites[0].euler)
-        self.assertIsNotNone(sensor_sites[0].quat)
+        assert_allclose(self.expected_quat, sensor_sites[0].quat)
 
         mjcf_force_sensor, mjcf_torque_sensor = mjcf_sensors
         self.assertAlmostEqual(f"force_{self.sensor.name()}",
@@ -325,6 +352,15 @@ class CameraTest(helpers.TestCase):
     test_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)
     expected_pos = [1.0, 2.0, 3.0]
     expected_euler = [90.0, 60.0, 45.0]
+    # Expected quaternion (wxyz) corresponding to roll=pi/2, pitch=pi/3,
+    # yaw=pi/4. Matches the wxyz order used by MJCF `<camera>`/`quat` and
+    # by `sdformat_mjcf.utils.sdf_utils.quat_to_list`.
+    expected_quat = [
+        0.701057384649978,
+        0.4304593345768794,
+        0.560985526796931,
+        -0.09229595564125716,
+    ]
 
     def setUp(self):
         self.mujoco = mjcf.RootElement(model="test")
@@ -344,7 +380,7 @@ class CameraTest(helpers.TestCase):
         self.assertEqual(1, len(mj_cameras))
         assert_allclose(self.expected_pos, mjcf_sensor.pos)
         self.assertIsNone(mjcf_sensor.euler)
-        self.assertIsNotNone(mjcf_sensor.quat)
+        assert_allclose(self.expected_quat, mjcf_sensor.quat)
 
     def test_camera_euler_xyz(self):
         """Camera uses euler angles when compiler eulerseq is XYZ."""

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_sensor.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_sensor.py
@@ -53,12 +53,25 @@ class Altimeter(helpers.TestCase):
         self.assertEqual(1, len(sensor_sites))
         self.assertEqual(self.sensor.name(), sensor_sites[0].name)
         assert_allclose(self.expected_pos, sensor_sites[0].pos)
-        assert_allclose(self.expected_euler, sensor_sites[0].euler)
+        self.assertIsNone(sensor_sites[0].euler)
+        self.assertIsNotNone(sensor_sites[0].quat)
 
         mjcf_altimeter = mjcf_sensors
         self.assertAlmostEqual(f"altimeter_{self.sensor.name()}",
                                mjcf_altimeter.name)
         self.assertAlmostEqual(self.sensor.name(), mjcf_altimeter.objname)
+
+    def test_site_euler_xyz(self):
+        """Site uses euler angles when compiler eulerseq is XYZ."""
+        self.mujoco.compiler.eulerseq = 'XYZ'
+        altimeter = sdf.Altimeter()
+        self.sensor.set_altimeter_sensor(altimeter)
+        add_sensor(self.body, self.sensor)
+
+        sensor_sites = self.body.get_children("site")
+        assert_allclose(self.expected_pos, sensor_sites[0].pos)
+        assert_allclose(self.expected_euler, sensor_sites[0].euler)
+        self.assertIsNone(sensor_sites[0].quat)
 
 
 class ImuSensorTest(helpers.TestCase):
@@ -92,7 +105,8 @@ class ImuSensorTest(helpers.TestCase):
         self.assertEqual(1, len(sensor_sites))
         self.assertEqual(self.sensor.name(), sensor_sites[0].name)
         assert_allclose(self.expected_pos, sensor_sites[0].pos)
-        assert_allclose(self.expected_euler, sensor_sites[0].euler)
+        self.assertIsNone(sensor_sites[0].euler)
+        self.assertIsNotNone(sensor_sites[0].quat)
 
         mjcf_accel, mjcf_gyro = mjcf_sensors
         self.assertAlmostEqual(f"accelerometer_{self.sensor.name()}",
@@ -135,7 +149,8 @@ class ImuSensorTest(helpers.TestCase):
         self.assertEqual(1, len(sensor_sites))
         self.assertEqual(self.sensor.name(), sensor_sites[0].name)
         assert_allclose(self.expected_pos, sensor_sites[0].pos)
-        assert_allclose(self.expected_euler, sensor_sites[0].euler)
+        self.assertIsNone(sensor_sites[0].euler)
+        self.assertIsNotNone(sensor_sites[0].quat)
 
         mjcf_accel, mjcf_gyro = mjcf_sensors
         self.assertAlmostEqual(f"accelerometer_{self.sensor.name()}",
@@ -176,6 +191,18 @@ class ImuSensorTest(helpers.TestCase):
         self.assertIsNone(mjcf_accel.noise)
         self.assertIsNone(mjcf_gyro.noise)
 
+    def test_site_euler_xyz(self):
+        """Site uses euler angles when compiler eulerseq is XYZ."""
+        self.mujoco.compiler.eulerseq = 'XYZ'
+        imu = sdf.IMU()
+        self.sensor.set_imu_sensor(imu)
+        add_sensor(self.body, self.sensor)
+
+        sensor_sites = self.body.get_children("site")
+        assert_allclose(self.expected_pos, sensor_sites[0].pos)
+        assert_allclose(self.expected_euler, sensor_sites[0].euler)
+        self.assertIsNone(sensor_sites[0].quat)
+
 
 class ForceTorqueSensorTest(helpers.TestCase):
     test_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)
@@ -208,7 +235,8 @@ class ForceTorqueSensorTest(helpers.TestCase):
         self.assertEqual(1, len(sensor_sites))
         self.assertEqual(self.sensor.name(), sensor_sites[0].name)
         assert_allclose(self.expected_pos, sensor_sites[0].pos)
-        assert_allclose(self.expected_euler, sensor_sites[0].euler)
+        self.assertIsNone(sensor_sites[0].euler)
+        self.assertIsNotNone(sensor_sites[0].quat)
 
         mjcf_force_sensor, mjcf_torque_sensor = mjcf_sensors
         self.assertAlmostEqual(f"force_{self.sensor.name()}",
@@ -252,7 +280,8 @@ class ForceTorqueSensorTest(helpers.TestCase):
         self.assertEqual(1, len(sensor_sites))
         self.assertEqual(self.sensor.name(), sensor_sites[0].name)
         assert_allclose(self.expected_pos, sensor_sites[0].pos)
-        assert_allclose(self.expected_euler, sensor_sites[0].euler)
+        self.assertIsNone(sensor_sites[0].euler)
+        self.assertIsNotNone(sensor_sites[0].quat)
 
         mjcf_force_sensor, mjcf_torque_sensor = mjcf_sensors
         self.assertAlmostEqual(f"force_{self.sensor.name()}",
@@ -279,6 +308,18 @@ class ForceTorqueSensorTest(helpers.TestCase):
                 "Only 'child_to_parent' is supported in <measure_direction>"
                 " of Force/Torque sensor", cm.output[0])
 
+    def test_site_euler_xyz(self):
+        """Site uses euler angles when compiler eulerseq is XYZ."""
+        self.mujoco.compiler.eulerseq = 'XYZ'
+        ft_sensor = sdf.ForceTorque()
+        self.sensor.set_force_torque_sensor(ft_sensor)
+        add_sensor(self.body, self.sensor)
+
+        sensor_sites = self.body.get_children("site")
+        assert_allclose(self.expected_pos, sensor_sites[0].pos)
+        assert_allclose(self.expected_euler, sensor_sites[0].euler)
+        self.assertIsNone(sensor_sites[0].quat)
+
 
 class CameraTest(helpers.TestCase):
     test_pose = Pose3d(1, 2, 3, pi / 2, pi / 3, pi / 4)
@@ -302,7 +343,19 @@ class CameraTest(helpers.TestCase):
         mj_cameras = self.body.get_children("camera")
         self.assertEqual(1, len(mj_cameras))
         assert_allclose(self.expected_pos, mjcf_sensor.pos)
+        self.assertIsNone(mjcf_sensor.euler)
+        self.assertIsNotNone(mjcf_sensor.quat)
+
+    def test_camera_euler_xyz(self):
+        """Camera uses euler angles when compiler eulerseq is XYZ."""
+        self.mujoco.compiler.eulerseq = 'XYZ'
+        camera_sensor = sdf.Camera()
+        self.sensor.set_camera_sensor(camera_sensor)
+        mjcf_sensor = add_sensor(self.body, self.sensor)
+
+        assert_allclose(self.expected_pos, mjcf_sensor.pos)
         assert_allclose(self.expected_euler, mjcf_sensor.euler)
+        self.assertIsNone(mjcf_sensor.quat)
 
 
 if __name__ == "__main__":

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_world.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_add_world.py
@@ -49,8 +49,11 @@ class WorldTest(helpers.TestCase):
 
         assert_allclose([0, 0, 0.5],
                         self.mujoco.worldbody.body[1].pos, rtol=1e-4)
-        assert_allclose([0, 0, 0],
-                        self.mujoco.worldbody.body[1].euler)
+        # Both models have identity rotation in lights.sdf; the converter emits
+        # `quat` (not `euler`) by default, so check the identity quaternion.
+        self.assertIsNone(self.mujoco.worldbody.body[1].euler)
+        assert_allclose(su.euler_list_to_quat_wxyz([0, 0, 0]),
+                        self.mujoco.worldbody.body[1].quat)
         self.assertEqual(2, len(self.mujoco.worldbody.body[1].geom))
         self.assertEqual("box_visual",
                          self.mujoco.worldbody.body[1].geom[1].name)
@@ -63,8 +66,9 @@ class WorldTest(helpers.TestCase):
 
         assert_allclose([0, 1.5, 0.5],
                         self.mujoco.worldbody.body[2].pos, rtol=1e-4)
-        assert_allclose([0, 0, 0],
-                        self.mujoco.worldbody.body[2].euler)
+        self.assertIsNone(self.mujoco.worldbody.body[2].euler)
+        assert_allclose(su.euler_list_to_quat_wxyz([0, 0, 0]),
+                        self.mujoco.worldbody.body[2].quat)
         self.assertEqual(2, len(self.mujoco.worldbody.body[1].geom))
         self.assertEqual("sphere_visual",
                          self.mujoco.worldbody.body[2].geom[1].name)

--- a/sdformat_mjcf/tests/sdformat_to_mjcf/test_cli.py
+++ b/sdformat_mjcf/tests/sdformat_to_mjcf/test_cli.py
@@ -88,6 +88,21 @@ class CLITest(unittest.TestCase):
             self.assertEqual(0, return_code)
             self.assertTrue(os.path.exists(output_file))
 
+    def test_euler_xyz_flag(self):
+        """Test that --euler_xyz sets compiler eulerseq to XYZ in the output."""
+        model_file = TEST_RESOURCES_DIR / "double_pendulum.sdf"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_file = path.join(temp_dir, "double_pendulum_euler.xml")
+            return_code = cli.main(
+                [str(model_file), output_file, "--euler_xyz"])
+            self.assertEqual(0, return_code)
+            self.assertTrue(os.path.exists(output_file))
+
+            # Verify the output contains the eulerseq compiler attribute
+            with open(output_file) as f:
+                content = f.read()
+            self.assertIn("eulerseq", content)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #124 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
